### PR TITLE
AIRAC 2406, other misc fixes

### DIFF
--- a/ScenarioFiles.xml
+++ b/ScenarioFiles.xml
@@ -138,7 +138,7 @@
 
       **QFA402** incorrect hemispherical level 
 
-      **JCR** has filed via `RPY` which is not in the current AIRAC. Students will need to reclear them `LLOYD DCT AV` and update FDR.
+      **JCR** has filed via `RPY` which is not in the current AIRAC. Students will need to reclear them `IGNES DCT AV` and update FDR.
 
       **VOZ810** conflicts with **RXA102** on approach. Student to either impose speed control ('reduce to final approach speed', 'best speed to the field', etc) or issue a go around. To remove conflict, delete VOZ810.
 
@@ -157,8 +157,8 @@
         <Aircraft Callsign="JCR" Type="LJ45" Delay="0">
           <Squawk Code="2000" ModeC="false" />
           <Position Latitude="-37.686042" Longitude="144.848743" Speed="0" Altitude="328" />
-          <FlightPlan Departure="YMML" Destination="YMAV" Alternative="" Rules="I" CruiseSpeed="350" ETD="0000" ATD="0000" RFL="6000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">ML LLOYD RPY AV</FlightPlan>
-          <Route>LLOYD AV YMAV</Route>
+          <FlightPlan Departure="YMML" Destination="YMAV" Alternative="" Rules="I" CruiseSpeed="350" ETD="0000" ATD="0000" RFL="6000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">ML IGNES RPY AV</FlightPlan>
+          <Route>IGNES AV YMAV</Route>
         </Aircraft>
         <Aircraft Callsign="HUS" Type="C172" Delay="0">
           <Squawk Code="1200" ModeC="false" />
@@ -2540,7 +2540,7 @@
           <Cleared Level="6000" />
           <Position Latitude="-38.06" Longitude="146.82" Speed="150" Altitude="6000" />
           <FlightPlan Active="true" Departure="YWSL" Destination="YNHL" Alternative="" Rules="1" CruiseSpeed="150" ETD="0000" ATD="0000" RFL="6000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/A NAV/RNP2 /v/">DCT DUNNE V434 MONTY ESDAN W382 WENDY W291 PUBAP DCT</FlightPlan>
-          <Route>DUNNE MONTY ESDAN LLOYD WENDY ESDIG UBGUT PUBAP</Route>
+          <Route>DUNNE MONTY ESDAN IGNES WENDY ESDIG UBGUT PUBAP</Route>
         </Aircraft>
         <Aircraft Callsign="FJS" Type="C182" Delay="0">
           <Squawk Code="1200" ModeC="true" />

--- a/ScenarioFiles.xml
+++ b/ScenarioFiles.xml
@@ -2203,7 +2203,7 @@
               <Squawk Code="4113" ModeC="true" />
               <Position Latitude="-26.06" Longitude="151.805" Speed="450" Altitude="29000" />
               <Cleared Level="3000" />
-              <FlightPlan Active="true" Departure="YBAS" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PULOL T11 ROM Y166 IDLEG V327 HAWKE Y340 LAMUG Y177 SMOKA SMOK1A/19R</FlightPlan>
+              <FlightPlan Active="true" Departure="YBAS" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PULOL T11 ROM Y166 IDLEG V327 IGUPI Y340 LAMUG Y177 SMOKA SMOK1A/19R</FlightPlan>
               <Route>LAMUG SMOKA RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="QFA987" Type="B738" Delay="180" StartAuto="true">
@@ -2224,7 +2224,7 @@
               <Squawk Code="4134" ModeC="true" />
               <Position Latitude="-25.916" Longitude="151.666" Speed="450" Altitude="33000" />
               <Cleared Level="3000" />
-              <FlightPlan Active="true" Departure="YPDN" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PALGA DCT NERTI J138 SURVO/N0458F370 J138 NTN T13 DOLIB/N0453F390 T13 EML UY409 NIROK Y177 SMOKA SMOK1A/19R</FlightPlan>
+              <FlightPlan Active="true" Departure="YPDN" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PALGA DCT NERTI J138 SURVO/N0458F370 J138 NTN T13 DOLIB/N0453F390 T13 EML UY409 BESBO Y177 SMOKA SMOK1A/19R</FlightPlan>
               <Route>LAMUG SMOKA RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="ANG3" Type="B763" Delay="90" StartAuto="true">
@@ -5298,33 +5298,33 @@
             <Cleared Level="37000" />
             <Position Latitude="-21.796724" Longitude="148.87873" Speed="400" Altitude="37000" />
             <FlightPlan Active="true" Departure="YBCS" Destination="YBBN" Alternative="YBCG" Rules="I" CruiseSpeed="400" ETD="0000" ATD="0000" RFL="37000" EETHours="02" EETMins="30" FuelHours="0" FuelMins="0" Remarks="CALL/VELOCITY    /v/">DCT AKROM Y177 SMOKA</FlightPlan>
-            <Route>COCKA RUROX NIROK LAMUG SMOKA YBBN</Route>
+            <Route>COCKA RUROX BESBO LAMUG SMOKA YBBN</Route>
           </Aircraft>
           <Aircraft Callsign="CPA103" Type="A333" Delay="0">
             <Squawk Code="236" ModeC="true" />
             <Cleared Level="37000" />
-            <Position Latitude="-20.087021000000004" Longitude="147.832536" Speed="438" Altitude="37000" />
+            <Position Latitude="-20.087021" Longitude="147.832536" Speed="438" Altitude="37000" />
             <FlightPlan Active="true" Departure="YBCS" Destination="YBBN" Alternative="YBCG" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="37000" EETHours="02" EETMins="30" FuelHours="0" FuelMins="0" Remarks="CALL/CATHAY    /v/">DCT AKROM Y177 SMOKA</FlightPlan>
-            <Route>COCKA RUROX NIROK LAMUG SMOKA YBBN</Route>
+            <Route>COCKA RUROX BESBO LAMUG SMOKA YBBN</Route>
           </Aircraft>
           <Aircraft Callsign="QLK381D" Type="DH8D" Delay="0">
             <Squawk Code="2000" ModeC="true" />
-            <Position Latitude="-25.318925999999998" Longitude="152.880254" Speed="0" Altitude="46" />
-            <FlightPlan Active="false" Departure="YHBA" Destination="YBBN" Alternative="YBSU" Rules="I" CruiseSpeed="300" ETD="0000" ATD="0000" RFL="21000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="CALL/QLINK    /v/">HAAVI W699 SOSTU V372 OTLEB V307 BN</FlightPlan>
+            <Position Latitude="-25.318926" Longitude="152.880254" Speed="0" Altitude="46" />
+            <FlightPlan Active="false" Departure="YHBA" Destination="YBBN" Alternative="YBSU" Rules="I" CruiseSpeed="300" ETD="0000" ATD="0000" RFL="21000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="CALL/QLINK    /v/">DCT HAAVI W699 SOSTU V372 OTLEB V307 BN</FlightPlan>
             <Route>SOSTU OTLEB MORBI REMOR GAYLA LUTKO IGBON EMSIT IRVUL BETSO BN</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ1238" Type="B738" Delay="0">
             <Squawk Code="2000" ModeC="true" />
-            <Position Latitude="-23.390524" Longitude="150.48000399999998" Speed="0" Altitude="23" />
+            <Position Latitude="-23.390524" Longitude="150.480004" Speed="0" Altitude="23" />
             <FlightPlan Active="false" Departure="YBRK" Destination="YBBN" Alternative="YBCG" Rules="I" CruiseSpeed="400" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="CALL/VELOCITY    /v/">DCT BUDGI V111 RUROX Y177 SMOKA</FlightPlan>
-            <Route>BUDGI RUROX NIROK LAMUG SMOKA YBBN</Route>
+            <Route>BUDGI RUROX BESBO LAMUG SMOKA YBBN</Route>
             <TimedMessages>
             <TimedMessage Time="900" Message="Velocity 1238, 737, IFR, Taxiing Rockhampton for Brisbane, Runway 33" />
             <TimedMessage Time="1100" Message="Ready Runway 33, Request Clearance" />
           </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="FD436" Type="BE20" Delay="0">
-            <Squawk Code="237" ModeC="true" />
+            <Squawk Code="2376" ModeC="true" />
             <Cleared Level="14000" />
             <Position Latitude="-24.488363" Longitude="151.348501" Speed="300" Altitude="14000" />
             <FlightPlan Active="true" Departure="YBBN" Destination="YBRK" Alternative="" Rules="I" CruiseSpeed="300" ETD="0000" ATD="0000" RFL="14000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="CALL/FLYDOC                /v/">DCT SAGLI V308 RK DCT</FlightPlan>
@@ -5334,20 +5334,20 @@
             <Squawk Code="4453" ModeC="true" />
             <Cleared Level="37000" />
             <Position Latitude="-24.223415" Longitude="148.987721" Speed="480" Altitude="37000" />
-            <FlightPlan Active="true" Departure="WMKK" Destination="YBCG" Alternative="YBBN" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="37000" EETHours="15" EETMins="00" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/XANADU    /v/">DOSNO DCT VENPA DCT VENIX DCT SURGA M635 BLI EML V129 BN Y177 GOMOL DCT</FlightPlan>
-            <Route>COOLA HAWKE BN DUNNI IDRIL YBCG</Route>
+            <FlightPlan Active="true" Departure="WMKK" Destination="YBCG" Alternative="YBBN" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="37000" EETHours="15" EETMins="00" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/XANADU    /v/">DOSNO DCT VENPA DCT VENIX DCT SURGA M635 BLI EML COOLA IGUPI BN Y177 GOMOL DCT</FlightPlan>
+            <Route>COOLA IGUPI BN DUNNI IDRIL YBCG</Route>
           </Aircraft>
           <Aircraft Callsign="QFA7474" Type="B744" Delay="0">
-            <Squawk Code="244" ModeC="true" />
+            <Squawk Code="2442" ModeC="true" />
             <Cleared Level="37000" />
-            <Position Latitude="-19.7233" Longitude="147.60908999999998" Speed="459" Altitude="37000" />
+            <Position Latitude="-19.7233" Longitude="147.60909" Speed="459" Altitude="37000" />
             <FlightPlan Active="true" Departure="YBCS" Destination="YBBN" Alternative="YBCG" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="37000" EETHours="02" EETMins="30" FuelHours="0" FuelMins="0" Remarks="CALL/QANTAS    /v/">DCT AKROM Y177 SMOKA</FlightPlan>
-            <Route>COCKA RUROX NIROK LAMUG SMOKA YBBN</Route>
+            <Route>COCKA RUROX BESBO LAMUG SMOKA YBBN</Route>
           </Aircraft>
           <Aircraft Callsign="TGG518" Type="A320" Delay="0">
-            <Squawk Code="663" ModeC="true" />
+            <Squawk Code="6632" ModeC="true" />
             <Cleared Level="37000" />
-            <Position Latitude="-32.236661" Longitude="149.86598000000004" Speed="430" Altitude="37000" />
+            <Position Latitude="-32.236661" Longitude="149.86598" Speed="430" Altitude="37000" />
             <FlightPlan Active="true" Departure="YMML" Destination="YBBN" Alternative="YBCG" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="37000" EETHours="02" EETMins="10" FuelHours="0" FuelMins="0" Remarks="CALLSIGN TIGGOZ    /v/">NONIX H66 BLAKA</FlightPlan>
             <Route>TW PEBDO WHITI IDNER BLAKA YBBN</Route>
           </Aircraft>
@@ -5385,15 +5385,15 @@
             <Squawk Code="1563" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.357767" Longitude="153.121344" Speed="1" Altitude="15" />
-            <FlightPlan Active="true" Departure="YBBN" Destination="WSSS" Alternative="WMKK" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="37000" EETHours="8" EETMins="40" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/SINGAPORE    /v/">WACKO3/19R WACKO DCT HAWKE V129 EML T13 NTN DCT</FlightPlan>
-            <Route>WACKO HAWKE COOLA EML MATAR LAKOT DOLIB NTN</Route>
+            <FlightPlan Active="true" Departure="YBBN" Destination="WSSS" Alternative="WMKK" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="37000" EETHours="8" EETMins="40" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/SINGAPORE    /v/">WACKO3/19R WACKO DCT IGUPI V129 EML T13 NTN DCT</FlightPlan>
+            <Route>WACKO IGUPI COOLA EML MATAR LAKOT DOLIB NTN</Route>
           </Aircraft>
           <Aircraft Callsign="QFA1880" Type="E190" Delay="550" StartAuto="true">
             <Squawk Code="3005" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.357767" Longitude="153.121344" Speed="1" Altitude="15" />
             <FlightPlan Active="true" Departure="YBBN" Destination="YBCS" Alternative="YBRK" Rules="I" CruiseSpeed="402" ETD="0000" ATD="0000" RFL="36000" EETHours="1" EETMins="40" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/QANTAS    /v/">BIXAD1/19R BIXAD Q67 UPOLO</FlightPlan>
-            <Route>BIXAD GUDSO TERUV KELPI LAMEK</Route>
+            <Route>BIXAD GUDSO TAPET LOAFA GLA RUNLA OVRON RUMKA BARIA UPOLO</Route>
           </Aircraft>
           <Aircraft Callsign="FD401" Type="B350" Delay="240" StartAuto="true">
             <Squawk Code="3012" ModeC="true" />
@@ -5410,35 +5410,35 @@
             <Squawk Code="1066" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.374708" Longitude="153.134358" Speed="1" Altitude="15" />
-            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="36000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/REX   /v/">SANEG1/19R SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
+            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="36000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/REX   /v/">SANEG1/19L SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
             <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ958" Type="B38M" Delay="1000" StartAuto="true">
             <Squawk Code="1067" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.374708" Longitude="153.134358" Speed="1" Altitude="15" />
-            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="34000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/REX   /v/">SANEG1/19R SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
+            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="34000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/VELOCITY   /v/">SANEG1/19L SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
             <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
           </Aircraft>
             <Aircraft Callsign="VOZ962" Type="B737" Delay="1200" StartAuto="true">
             <Squawk Code="1070" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.374708" Longitude="153.134358" Speed="1" Altitude="15" />
-            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="36000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/REX   /v/">SANEG1/19R SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
+            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="36000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/VELOCITY   /v/">SANEG1/19L SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
             <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
           </Aircraft>
           <Aircraft Callsign="JST930" Type="A320" Delay="1400" StartAuto="true">
             <Squawk Code="3643" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.357767" Longitude="153.121344" Speed="1" Altitude="15" />
-            <FlightPlan Active="true" Departure="YBBN" Destination="YBCS" Alternative="YBRK" Rules="I" CruiseSpeed="402" ETD="0000" ATD="0000" RFL="36000" EETHours="1" EETMins="40" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/QANTAS    /v/">BIXAD1/19R BIXAD Q67 UPOLO</FlightPlan>
-            <Route>BIXAD GUDSO TERUV KELPI LAMEK</Route>
+            <FlightPlan Active="true" Departure="YBBN" Destination="YBCS" Alternative="YBRK" Rules="I" CruiseSpeed="402" ETD="0000" ATD="0000" RFL="36000" EETHours="1" EETMins="40" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/JETSTAR    /v/">BIXAD1/19R BIXAD Q67 UPOLO</FlightPlan>
+            <Route>BIXAD GUDSO TAPET LOAFA GLA RUNLA OVRON RUMKA BARIA UPOLO</Route>
           </Aircraft>
           <Aircraft Callsign="QFA533" Type="B738" Delay="1600" StartAuto="true">
             <Squawk Code="1071" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.374708" Longitude="153.134358" Speed="1" Altitude="15" />
-            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="34000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/REX   /v/">SANEG1/19R SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
+            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="34000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/QANTAS   /v/">SANEG1/19L SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
             <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
           </Aircraft>
         </Targets>

--- a/ScenarioFiles.xml
+++ b/ScenarioFiles.xml
@@ -446,43 +446,43 @@
             <Squawk Code="1234" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.51250000" Longitude="149.90805556" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA490" Type="B738" Delay="0">
             <Squawk Code="1236" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.02166667" Longitude="151.00444444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
             <Route>DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="JST522" Type="A320" Delay="0">
             <Squawk Code="1235" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.14750000" Longitude="151.09444444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
             <Route>NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA464" Type="B738" Delay="0">
             <Squawk Code="3134" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.38166667" Longitude="150.20888889" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="TGG264" Type="B738" Delay="0">
             <Squawk Code="4265" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.23666667" Longitude="150.52638889" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
-            <Route>RWY34L SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <Route>SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ871" Type="B738" Delay="0">
             <Squawk Code="1237" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.12638889" Longitude="150.77194444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
-            <Route>TAMMI RWY34L SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <Route>TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA543" Type="B738" Delay="0">
             <Squawk Code="5234" ModeC="true" />
@@ -502,8 +502,8 @@
             <Squawk Code="2646" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.62722222" Longitude="149.64916667" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="JST821" Type="B738" Delay="0">
             <Squawk Code="5373" ModeC="true" />
@@ -672,43 +672,43 @@
             <Squawk Code="1234" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.51250000" Longitude="149.90805556" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA490" Type="B738" Delay="0">
             <Squawk Code="1236" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.02166667" Longitude="151.00444444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
             <Route>DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="JST522" Type="A320" Delay="0">
             <Squawk Code="1235" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.14750000" Longitude="151.09444444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
             <Route>NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA464" Type="B738" Delay="0">
             <Squawk Code="3134" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.38166667" Longitude="150.20888889" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="TGG264" Type="B738" Delay="0">
             <Squawk Code="4265" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.23666667" Longitude="150.52638889" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
-            <Route>RWY34L SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <Route>SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ871" Type="B738" Delay="0">
             <Squawk Code="1237" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.12638889" Longitude="150.77194444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
-            <Route>TAMMI RWY34L SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <Route>TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA543" Type="B738" Delay="0">
             <Squawk Code="5234" ModeC="true" />
@@ -728,8 +728,8 @@
             <Squawk Code="2646" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.62722222" Longitude="149.64916667" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="JST821" Type="B738" Delay="0">
             <Squawk Code="5373" ModeC="true" />

--- a/ScenarioFiles.xml
+++ b/ScenarioFiles.xml
@@ -103,14 +103,14 @@
             <Squawk Code="1232" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-37.14388889" Longitude="146.22000000" Speed="180" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="0" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="0" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
             <Route>LIZZI NEFER BELTA RWY16 YMML</Route>
           </Aircraft>
           <Aircraft Callsign="QFA409" Type="A332" Delay="0" StartAuto="true">
             <Squawk Code="1222" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-37.40972222" Longitude="145.71472222" Speed="180" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="37000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="37000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
             <Route>LIZZI NEFER BELTA RWY16 YMML</Route>
           </Aircraft>
           <Aircraft Callsign="QFA776" Type="A332" Delay="0" StartAuto="true">
@@ -205,7 +205,7 @@
         <Aircraft Callsign="QLK150D" Type="DH8D" Delay="0">
           <Squawk Code="2000" ModeC="false" />
           <Position Latitude="-37.666607" Longitude="144.852269" Speed="0" Altitude="381" />
-          <FlightPlan Departure="YMML" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="310" ETD="0000" ATD="0000" RFL="21000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">ML LIZZI Q29 RAZZI H65 WOL BOREE IGDAM HUUGO</FlightPlan>
+          <FlightPlan Departure="YMML" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="310" ETD="0000" ATD="0000" RFL="21000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">ML LIZZI Q29 LEECE H65 WOL BOREE IGDAM HUUGO</FlightPlan>
           <Route>LIZZI WOL BOREE IGDAM HUUGO BN YBBN</Route>
         </Aircraft>
         <Aircraft Callsign="JST627" Type="A321" Delay="0">
@@ -226,14 +226,14 @@
           <Squawk Code="1232" ModeC="true" />
           <Cleared Approach="true" />
           <Position Latitude="-37.14388889" Longitude="146.22000000" Speed="180" Altitude="3000" />
-          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="0" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="0" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>LIZZI NEFER BELTA RWY16 YMML</Route>
         </Aircraft>
         <Aircraft Callsign="QFA411" Type="A332" Delay="0" StartAuto="true">
           <Squawk Code="1222" ModeC="true" />
           <Cleared Approach="true" />
           <Position Latitude="-37.44500000" Longitude="145.64833333" Speed="180" Altitude="3000" />
-          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="37000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="37000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>LIZZI NEFER BELTA RWY16 YMML</Route>
         </Aircraft>
         <Aircraft Callsign="QFA778" Type="A332" Delay="0" StartAuto="true">
@@ -379,13 +379,13 @@
           <Aircraft Callsign="QFA427" Type="B738" Delay="0">
             <Squawk Code="2000" ModeC="false" />
             <Position Latitude="-33.931849" Longitude="151.179663" Speed="0" Altitude="13" />
-            <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT TESAT H65 RAZZI Q29 ML DCT</FlightPlan>
+            <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT TESAT H65 LEECE Q29 ML DCT</FlightPlan>
             <Route>WOL YMML</Route>
           </Aircraft>
           <Aircraft Callsign="JST527" Type="A320" Delay="0">
             <Squawk Code="2000" ModeC="false" />
             <Position Latitude="-33.93472200000001" Longitude="151.177124" Speed="0" Altitude="3" />
-            <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="40000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT TESAT H65 RAZZI Q29 ML DCT</FlightPlan>
+            <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="40000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT TESAT H65 LEECE Q29 ML DCT</FlightPlan>
             <Route>WOL YMML</Route>
           </Aircraft>
           <Aircraft Callsign="JST578" Type="A320" Delay="0">
@@ -639,7 +639,7 @@
           <Aircraft Callsign="JST527" Type="A320" Delay="990" StartAuto="true">
               <Squawk Code="0" ModeC="false" />
               <Position Latitude="-33.93472200000001" Longitude="151.177124" Speed="0" Altitude="3" />
-              <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="40000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT WOL H65 RAZZI Q29 ML DCT</FlightPlan>
+              <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="40000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT WOL H65 LEECE Q29 ML DCT</FlightPlan>
               <Route>WOL</Route>
               <TimedMessages>
                   <TimedMessage Time="1290" Message="Request clearance to Melbourne (bay 55)" />
@@ -816,14 +816,14 @@
           <Cleared Approach="true" />
           <Position Latitude="-26.78138889" Longitude="152.55861111" Speed="250" Altitude="4000" />
           <FlightPlan Active="true" Departure="YBMK" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT MK W889 RK V307 SUSGI DCT SMOKA SMOK9A/19R</FlightPlan>
-          <Route>SMOKA</Route>
+          <Route>SMOKA RWY19R</Route>
         </Aircraft>
         <Aircraft Callsign="AVN22" Type="B738" Delay="0" StartAuto="true">
           <Squawk Code="1009" ModeC="true" />
           <Cleared Approach="true" />
           <Position Latitude="-26.45166667" Longitude="152.19694444" Speed="250" Altitude="3000" />
           <FlightPlan Active="true" Departure="YBCS" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT AKROM Y177 SMOKA SMOK9A/19R</FlightPlan>
-          <Route>SMOKA</Route>
+          <Route>SMOKA RWY19R</Route>
         </Aircraft>
         <Aircraft Callsign="VEA" Type="SF34" Delay="0" StartAuto="true">
           <Squawk Code="1011" ModeC="true" />
@@ -837,14 +837,14 @@
           <Cleared Approach="true" />
           <Position Latitude="-28.56027778" Longitude="153.43694444" Speed="250" Altitude="3000" />
           <FlightPlan Active="true" Departure="YCFS" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CFS W192 GOMOL GOMO2A/19L</FlightPlan>
-          <Route>GOMOL</Route>
+          <Route>GOMOL RWY19L</Route>
         </Aircraft>
         <Aircraft Callsign="QTR900" Type="B77W" Delay="0" StartAuto="true">
           <Squawk Code="1017" ModeC="true" />
           <Cleared Approach="true" />
           <Position Latitude="-28.76388889" Longitude="153.29750000" Speed="250" Altitude="3000" />
           <FlightPlan Active="true" Departure="YSSY" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT OLSEM Y193 BANDA H252 GOMOL GOMO2A/19L</FlightPlan>
-          <Route>GOMOL</Route>
+          <Route>GOMOL RWY19L</Route>
         </Aircraft>
 
         <Aircraft Callsign="JST813" Type="A320" Delay="0">
@@ -1008,7 +1008,7 @@
           <Cleared Approach="true" />
           <Position Latitude="-26.78138889" Longitude="152.55861111" Speed="250" Altitude="4000" />
           <FlightPlan Active="true" Departure="YBMK" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT MK W889 RK V307 SUSGI DCT SMOKA SMOK9A/19R</FlightPlan>
-          <Route>SMOKA</Route>
+          <Route>SMOKA RWY19R</Route>
         </Aircraft>
         <Aircraft Callsign="QFA1938" Type="E190" Delay="0" StartAuto="true">
           <Squawk Code="1007" ModeC="true" />
@@ -1022,21 +1022,21 @@
           <Cleared Approach="true" />
           <Position Latitude="-26.61527778" Longitude="152.35444444" Speed="250" Altitude="4000" />
           <FlightPlan Active="true" Departure="YBCS" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT AKROM Y177 SMOKA SMOK9A/19R</FlightPlan>
-          <Route>SMOKA</Route>
+          <Route>SMOKA RWY19R</Route>
         </Aircraft>
         <Aircraft Callsign="AVN20" Type="B738" Delay="0" StartAuto="true">
           <Squawk Code="1009" ModeC="true" />
           <Cleared Approach="true" />
           <Position Latitude="-26.45166667" Longitude="152.19694444" Speed="250" Altitude="3000" />
           <FlightPlan Active="true" Departure="YBCS" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT AKROM Y177 SMOKA SMOK9A/19R</FlightPlan>
-          <Route>SMOKA</Route>
+          <Route>SMOKA RWY19R</Route>
         </Aircraft>
         <Aircraft Callsign="QLK417D" Type="DH8D" Delay="0" StartAuto="true">
           <Squawk Code="1010" ModeC="true" />
           <Cleared Approach="true" />
           <Position Latitude="-26.21444444" Longitude="152.13750000" Speed="250" Altitude="4000" />
           <FlightPlan Active="true" Departure="YBRK" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">RK V307 SUSGI DCT SMOKA SMOK9A/19R</FlightPlan>
-          <Route>SMOKA</Route>
+          <Route>SMOKA RWY19R</Route>
         </Aircraft>
         <Aircraft Callsign="VEP" Type="SF34" Delay="0" StartAuto="true">
           <Squawk Code="1011" ModeC="true" />
@@ -1050,28 +1050,28 @@
           <Cleared Approach="true" />
           <Position Latitude="-28.34055556" Longitude="153.44361111" Speed="250" Altitude="3000" />
           <FlightPlan Active="true" Departure="YSSY" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT OLSEM Y193 BANDA H252 GOMOL GOMO2A/19L</FlightPlan>
-          <Route>GOMOL</Route>
+          <Route>GOMOL RWY19L</Route>
         </Aircraft>
         <Aircraft Callsign="FD427" Type="B350" Delay="0" StartAuto="true">
           <Squawk Code="1015" ModeC="true" />
           <Cleared Approach="true" />
           <Position Latitude="-28.56027778" Longitude="153.43694444" Speed="250" Altitude="3000" />
           <FlightPlan Active="true" Departure="YCFS" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CFS W192 GOMOL GOMO2A/19L</FlightPlan>
-          <Route>GOMOL</Route>
+          <Route>GOMOL RWY19L</Route>
         </Aircraft>
         <Aircraft Callsign="TFX902" Type="B733" Delay="0" StartAuto="true">
           <Squawk Code="1016" ModeC="true" />
           <Cleared Approach="true" />
           <Position Latitude="-26.12444444" Longitude="151.86833333" Speed="250" Altitude="4000" />
           <FlightPlan Active="true" Departure="YBCS" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT AKROM Y177 SMOKA SMOK9A/19R</FlightPlan>
-          <Route>SMOKA</Route>
+          <Route>SMOKA RWY19R</Route>
         </Aircraft>
         <Aircraft Callsign="QTR898" Type="B77W" Delay="0" StartAuto="true">
           <Squawk Code="1017" ModeC="true" />
           <Cleared Approach="true" />
           <Position Latitude="-28.76388889" Longitude="153.29750000" Speed="250" Altitude="3000" />
           <FlightPlan Active="true" Departure="YSSY" Destination="YBBN" Alternative="" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT OLSEM Y193 BANDA H252 GOMOL GOMO2A/19L</FlightPlan>
-          <Route>GOMOL</Route>
+          <Route>GOMOL RWY19L</Route>
         </Aircraft>
 
         <Aircraft Callsign="JST811" Type="A320" Delay="0">
@@ -1215,7 +1215,7 @@
       <Aircraft Callsign="FD580" Type="PC12" Delay="120" StartAuto="true">
         <Squawk Code="0" ModeC="false" />
         <Position Latitude="-34.950071" Longitude="138.522121" Speed="0" Altitude="23" />
-        <FlightPlan Departure="YPAD" Destination="YWHA" Alternative="" Active="false" Rules="I" CruiseSpeed="284" ETD="0000" ATD="0000" RFL="16000" EETHours="00" EETMins="34" FuelHours="3" FuelMins="00" Remarks="NAV/RNP2 RTF/FLYDOC /v/">DCT AD W238 WAKEN W142 COMAC DCT </FlightPlan>
+        <FlightPlan Departure="YPAD" Destination="YWHA" Alternative="" Active="false" Rules="I" CruiseSpeed="284" ETD="0000" ATD="0000" RFL="16000" EETHours="00" EETMins="34" FuelHours="3" FuelMins="00" Remarks="NAV/RNP2 RTF/FLYDOC /v/">DCT AD W238 RUKNA W142 COMAC DCT </FlightPlan>
         <Route>COLPY</Route>
         <TimedMessages>
           <TimedMessage Time="750" Message="Request Clearance to Whyalla" />
@@ -1337,35 +1337,35 @@
         <Cleared Approach="true" />
         <Position Latitude="-34.72777778" Longitude="137.61583333" Speed="200" Altitude="3000" />
         <FlightPlan Departure="YPLC" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="268" ETD="0000" ATD="0000" RFL="15000" EETHours="0" EETMins="38" FuelHours="2" FuelMins="45" Remarks="NAV/RNP2 RTF/FLYDOC /v/">DCT TEKOD V707 RIKAB RIKA8A/23</FlightPlan>
-        <Route>RIKAB</Route>
+        <Route>RIKAB RWY23</Route>
       </Aircraft>
       <Aircraft Callsign="VOZ231" Type="B738" Delay="0" StartAuto="true">
         <Squawk Code="3540" ModeC="true" />
         <Cleared Approach="true" />
         <Position Latitude="-35.57027778" Longitude="139.46166667" Speed="200" Altitude="3000" />
         <FlightPlan Departure="YMML" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="454" ETD="0000" ATD="0000" RFL="34000" EETHours="1" EETMins="11" FuelHours="2" FuelMins="22" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT NEVIS H345 DRINA DRIN9A/23</FlightPlan>
-        <Route>DRINA</Route>
+        <Route>DRINA RWY23</Route>
       </Aircraft>
       <Aircraft Callsign="RXA4357" Type="SF34" Delay="0" StartAuto="true">
         <Squawk Code="2750" ModeC="true" />
         <Cleared Approach="true" />
         <Position Latitude="-34.70500000" Longitude="137.24138889" Speed="200" Altitude="3000" />
         <FlightPlan Departure="YPLC" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="270" ETD="0000" ATD="0000" RFL="15000" EETHours="0" EETMins="45" FuelHours="1" FuelMins="59" Remarks="NAV/RNP2 RTF/QLINK /v/">DCT PLC V707 RIKAB RIKA8A/23</FlightPlan>
-        <Route>RIKAB</Route>
+        <Route>RIKAB RWY23</Route>
       </Aircraft>
       <Aircraft Callsign="VOZ718" Type="B738" Delay="0" StartAuto="true">
         <Squawk Code="3007" ModeC="true" />
         <Cleared Approach="true" />
         <Position Latitude="-34.78833333" Longitude="136.71527778" Speed="200" Altitude="3000" />
         <FlightPlan Departure="YPPH" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="37000" EETHours="2" EETMins="28" FuelHours="3" FuelMins="58" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT HECTO Y135 DADRU Y39 RIKAB RIKA8A/23</FlightPlan>
-        <Route>RIKAB</Route>
+        <Route>RIKAB RWY23</Route>
       </Aircraft>
       <Aircraft Callsign="JST961" Type="A320" Delay="0" StartAuto="true">
         <Squawk Code="4503" ModeC="true" />
         <Cleared Approach="true" />
         <Position Latitude="-33.17666667" Longitude="138.51250000" Speed="200" Altitude="3000" />
         <FlightPlan Departure="YBCS" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="34000" EETHours="2" EETMins="53" FuelHours="4" FuelMins="01" Remarks="NAV/RNP2 RTF/JETSTAR /v/">DCT NONUM DCT RUSSO DCT NONET DCT OOM J37 ATLIB H630 NIMEK H135 KLAVA RAYN2A/23</FlightPlan>
-        <Route>KLAVA</Route>
+        <Route>KLAVA RWY23</Route>
       </Aircraft>
     </Targets>
     </ScenarioFile>
@@ -2203,7 +2203,7 @@
               <Squawk Code="4113" ModeC="true" />
               <Position Latitude="-26.06" Longitude="151.805" Speed="450" Altitude="29000" />
               <Cleared Level="3000" />
-              <FlightPlan Active="true" Departure="YBAS" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PULOL T11 ROM Y166 ROWLO V327 HAWKE Y340 LAMUG Y177 SMOKA SMOK1A/19R</FlightPlan>
+              <FlightPlan Active="true" Departure="YBAS" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PULOL T11 ROM Y166 IDLEG V327 HAWKE Y340 LAMUG Y177 SMOKA SMOK1A/19R</FlightPlan>
               <Route>LAMUG SMOKA RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="QFA987" Type="B738" Delay="180" StartAuto="true">
@@ -2308,21 +2308,21 @@
             <Squawk Code="4213" ModeC="true" />
             <Position Latitude="-37.306667" Longitude="145.915" Speed="440" Altitude="24000" />
             <Cleared Level="9000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMAV" Alternative="" Rules="1" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 RAZZI Q29 ML JAYBI5/18</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMAV" Alternative="" Rules="1" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 LEECE Q29 ML JAYBI5/18</FlightPlan>
             <Route>LIZZI ML JAYBI RWY18</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ876" Type="B738" Delay="0">
             <Squawk Code="4117" ModeC="true" />
             <Position Latitude="-37.202087" Longitude="146.119146" Speed="410" Altitude="24000" />
             <Cleared Level="9000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="410" ETD="0000" ATD="0000" RFL="40000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="410" ETD="0000" ATD="0000" RFL="40000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
             <Route>LIZZI RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="QFA455" Type="A332" Delay="0">
             <Squawk Code="3111" ModeC="true" />
             <Position Latitude="-37.00189199999999" Longitude="146.500724" Speed="420" Altitude="26000" />
             <Cleared Level="9000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
             <Route>LIZZI RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="QFA692" Type="B738" Delay="0">
@@ -2336,7 +2336,7 @@
             <Squawk Code="4112" ModeC="true" />
             <Position Latitude="-36.51083333" Longitude="147.39500000" Speed="410" Altitude="38000" />
             <Cleared Level="9000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="410" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="410" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
             <Route>NABBA BULLA LIZZI RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="QFA699" Type="B738" Delay="30" StartAuto="true">
@@ -2357,7 +2357,7 @@
             <Squawk Code="4115" ModeC="true" />
             <Position Latitude="-36.004223" Longitude="148.301395" Speed="410" Altitude="38000" />
             <Cleared Level="9000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="410" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT TESAT H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="410" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT TESAT H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
             <Route>RUMIE NABBA BULLA LIZZI RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="YMF7000" Type="F100" Delay="240" StartAuto="true">
@@ -2504,7 +2504,7 @@
           <Squawk Code="2742" ModeC="true" />
           <Cleared Level="9000" />
           <Position Latitude="-37.19" Longitude="146.14" Speed="350" Altitude="18000" />
-          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2 /v/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9V/34V</FlightPlan>
+          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2 /v/">DCT WOL H65 LEECE Q29 LIZZI LIZI9V/34V</FlightPlan>
           <Route>LUVAS LIZZI ATPER MAITE IGPON MONTY EGEKA SHEED HORSH RWY34</Route>
         </Aircraft>
         <Aircraft Callsign="TFX15" Type="AT43" Delay="0">
@@ -2525,14 +2525,14 @@
           <Squawk Code="2411" ModeC="true" />
           <Cleared Level="9000" />
           <Position Latitude="-35.035" Longitude="150.0" Speed="480" Altitude="43000" />
-          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="489" ETD="0000" ATD="0000" RFL="43000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/D NAV/RNP2 /v/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/34</FlightPlan>
+          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="489" ETD="0000" ATD="0000" RFL="43000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/D NAV/RNP2 /v/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/34</FlightPlan>
           <Route>TANTA RUMIE NABBA BULLA LUVAS LIZZI RWY34</Route>
         </Aircraft>
         <Aircraft Callsign="JST513" Type="A320" Delay="0">
           <Squawk Code="2746" ModeC="true" />
           <Cleared Level="9000" />
           <Position Latitude="-35.88" Longitude="148.565" Speed="450" Altitude="38000" />
-          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2 /v/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9V/34V</FlightPlan>
+          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2 /v/">DCT WOL H65 LEECE Q29 LIZZI LIZI9V/34V</FlightPlan>
           <Route>NABBA BULLA LUVAS LIZZI ATPER MAITE IGPON MONTY EGEKA SHEED HORSH RWY34</Route>
         </Aircraft>
         <Aircraft Callsign="ETS" Type="BE58" Delay="0">
@@ -2822,77 +2822,77 @@
           <Squawk Code="4765" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-37.361944" Longitude="145.805278" Speed="300" Altitude="17000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ874" Type="B738" Delay="0" StartAuto="false">
           <Squawk Code="1213" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-37.079167" Longitude="146.351667" Speed="400" Altitude="26000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="JST531" Type="A21N" Delay="0" StartAuto="false">
           <Squawk Code="3227" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.846944" Longitude="146.781667" Speed="410" Altitude="31000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHOFE OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHOFE OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="CPA3122" Type="B748" Delay="0" StartAuto="false">
           <Squawk Code="3114" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.608611" Longitude="147.214444" Speed="480" Altitude="36000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1L1O1S2T1 NAV/RNP2 COM/INTEGRATED DAT/1FANSER2PDC SUR/260B RSP180 DOF/240101 REG/BLJK EET/YMMM0050 SEL/CKDH CODE/780A6E OPR/CPA ORGN/EDDFCPAX PER/D RMK/CARGO AIRCRAFT /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1L1O1S2T1 NAV/RNP2 COM/INTEGRATED DAT/1FANSER2PDC SUR/260B RSP180 DOF/240101 REG/BLJK EET/YMMM0050 SEL/CKDH CODE/780A6E OPR/CPA ORGN/EDDFCPAX PER/D RMK/CARGO AIRCRAFT /V/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="RXA161" Type="B738" Delay="0" StartAuto="false">
           <Squawk Code="3765" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.556667" Longitude="147.3225" Speed="450" Altitude="38000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1L1O1S2 NAV/RNP2 DOF/240101 REG/VHRQP SEL/CEDQ CODE/7C585F OPR/RXA ORGN/KAUSFFLX PER/C /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1L1O1S2 NAV/RNP2 DOF/240101 REG/VHRQP SEL/CEDQ CODE/7C585F OPR/RXA ORGN/KAUSFFLX PER/C /V/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ886" Type="B38M" Delay="0" StartAuto="false">
           <Squawk Code="6732" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.379167" Longitude="147.633056" Speed="450" Altitude="38000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="TFX22" Type="B734" Delay="0" StartAuto="false">
           <Squawk Code="0127" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.240833" Longitude="147.891944" Speed="440" Altitude="34000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDFGHIM3RWZ/LB1" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O2S2 NAV/RNP2 DOF/240101 REG/ZKTLJ SEL/EPCR CODE/C822C4 OPR/TFX PER/C RMK/TCAS EQUIPPED /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDFGHIM3RWZ/LB1" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O2S2 NAV/RNP2 DOF/240101 REG/ZKTLJ SEL/EPCR CODE/C822C4 OPR/TFX PER/C RMK/TCAS EQUIPPED /V/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>RUMIE NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="TAA406" Type="A306" Delay="0" StartAuto="false">
           <Squawk Code="5552" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.051667" Longitude="148.237778" Speed="470" Altitude="40000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="400" EETHours="1" EETMins="20" FuelHours="2" FuelMins="15" Remarks="PBN/A1B1D1O1S1S2 NAV/RNP2 DOF/240112 REG/VHTAE SEL/DGCF CODE/8961D3 OPR/TAA PER/C /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="400" EETHours="1" EETMins="20" FuelHours="2" FuelMins="15" Remarks="PBN/A1B1D1O1S1S2 NAV/RNP2 DOF/240112 REG/VHTAE SEL/DGCF CODE/8961D3 OPR/TAA PER/C /V/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>RUMIE NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ888" Type="B738" Delay="0" StartAuto="false">
           <Squawk Code="2365" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-35.981667" Longitude="148.351944" Speed="450" Altitude="36000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>RUMIE NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="QFA485" Type="B738" Delay="0" StartAuto="false">
           <Squawk Code="6564" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-35.684722" Longitude="148.869722" Speed="450" Altitude="38000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>RUMIE NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="8AX" Type="C700" Delay="0" StartAuto="false">
           <Squawk Code="7104" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-35.335556" Longitude="149.480833" Speed="450" Altitude="43000" />
-          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="430" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VH8AX SEL/ESAM CODE/7C6DDA OPR/JETSTREAM AVIATION PER/C /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="430" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VH8AX SEL/ESAM CODE/7C6DDA OPR/JETSTREAM AVIATION PER/C /V/">DCT WOL H65 LEECE Q29 LIZZI LIZI9A/16</FlightPlan>
           <Route>RUMIE NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
     // Off Route Arrivals
@@ -2925,7 +2925,7 @@
           <Squawk Code="1714" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-35.789722" Longitude="148.703611" Speed="450" Altitude="36000" />
-          <FlightPlan Departure="YSSY" Destination="YMAV" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHOFE OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DCT WOL H65 RAZZI Q29 ML JAYBI5/18</FlightPlan>
+          <FlightPlan Departure="YSSY" Destination="YMAV" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHOFE OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DCT WOL H65 LEECE Q29 ML JAYBI5/18</FlightPlan>
           <Route>RUMIE NABBA BULLA LUVAS LIZZI ML JAYBI RWY18</Route>
           <TimedMessages>
             <TimedMessage Time="1140" Message="If there is less than 7nm separation with VOZ888, apply vertical separation (1000ft above VOZ888's last vacated level). Handoff when ready to MAE with vertical separation in place" />
@@ -3079,8 +3079,8 @@
           <Squawk Code="4165" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-33.970049" Longitude="151.19351" Speed="0" Altitude="3" />
-          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="30" FuelHours="0" FuelMins="0" Remarks="REG/VHYFE PER/C OPR/VIRGIN AUSTRALIA    /v/">MARUB6/34R WOL H65 RAZZI Q29 LIZZI</FlightPlan>
-          <Route>MARUB WOL RAZZI YMML</Route>
+          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="30" FuelHours="0" FuelMins="0" Remarks="REG/VHYFE PER/C OPR/VIRGIN AUSTRALIA    /v/">MARUB6/34R WOL H65 LEECE Q29 LIZZI</FlightPlan>
+          <Route>MARUB WOL LEECE YMML</Route>
         </Aircraft>
         <Aircraft Callsign="RXA143" Type="B738" Delay="0">
           <Squawk Code="6234" ModeC="true" />
@@ -3093,8 +3093,8 @@
           <Squawk Code="5143" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-33.970049" Longitude="151.19351" Speed="0" Altitude="3" />
-          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="30" FuelHours="0" FuelMins="0" Remarks="REG/VHVZA PER/C OPR/QANTAS    /v/">MARUB6/34R WOL H65 RAZZI Q29 LIZZI</FlightPlan>
-          <Route>MARUB WOL RAZZI YMML</Route>
+          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="30" FuelHours="0" FuelMins="0" Remarks="REG/VHVZA PER/C OPR/QANTAS    /v/">MARUB6/34R WOL H65 LEECE Q29 LIZZI</FlightPlan>
+          <Route>MARUB WOL LEECE YMML</Route>
         </Aircraft>
         <Aircraft Callsign="ANZ223" Type="A21N" Delay="0">
           <Squawk Code="1239" ModeC="true" />
@@ -3260,8 +3260,8 @@
           <Squawk Code="4165" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-33.970049" Longitude="151.19351" Speed="0" Altitude="3" />
-          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="30" FuelHours="0" FuelMins="0" Remarks="REG/VHYFE PER/C OPR/VIRGIN AUSTRALIA    /v/">MARUB6/34R WOL H65 RAZZI Q29 LIZZI</FlightPlan>
-          <Route>MARUB WOL RAZZI YMML</Route>
+          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="30" FuelHours="0" FuelMins="0" Remarks="REG/VHYFE PER/C OPR/VIRGIN AUSTRALIA    /v/">MARUB6/34R WOL H65 LEECE Q29 LIZZI</FlightPlan>
+          <Route>MARUB WOL LEECE YMML</Route>
         </Aircraft>
         <Aircraft Callsign="RXA143" Type="B738" Delay="0">
           <Squawk Code="6234" ModeC="true" />
@@ -3274,8 +3274,8 @@
           <Squawk Code="5143" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-33.970049" Longitude="151.19351" Speed="0" Altitude="3" />
-          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="30" FuelHours="0" FuelMins="0" Remarks="REG/VHVZA PER/C OPR/QANTAS    /v/">MARUB6/34R WOL H65 RAZZI Q29 LIZZI</FlightPlan>
-          <Route>MARUB WOL RAZZI YMML</Route>
+          <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="30" FuelHours="0" FuelMins="0" Remarks="REG/VHVZA PER/C OPR/QANTAS    /v/">MARUB6/34R WOL H65 LEECE Q29 LIZZI</FlightPlan>
+          <Route>MARUB WOL LEECE YMML</Route>
         </Aircraft>
         <Aircraft Callsign="ANZ223" Type="A21N" Delay="0">
           <Squawk Code="1239" ModeC="true" />
@@ -3441,15 +3441,15 @@
       <Squawk Code="7642" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.930278" Longitude="151.171667" Speed="1" Altitude="7" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">KAMPI6/16R WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">KAMPI6/16R WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
     </Aircraft>
 	<Aircraft Callsign="VOZ874" Type="B738" Delay="0" StartAuto="false">
       <Squawk Code="2435" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.930278" Longitude="151.171667" Speed="0" Altitude="7" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">KAMPI6/16R WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">KAMPI6/16R WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
         <TimedMessage Time="100" Message="Takeoff" />
       </TimedMessages>
@@ -3458,8 +3458,8 @@
       <Squawk Code="3227" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.930278" Longitude="151.171667" Speed="0" Altitude="7" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHOFE OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">KAMPI6/16R WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHOFE OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">KAMPI6/16R WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
         <TimedMessage Time="200" Message="Takeoff" />
       </TimedMessages>
@@ -3468,8 +3468,8 @@
       <Squawk Code="6214" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.930278" Longitude="151.171667" Speed="0" Altitude="7" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 RNVD1A1 SUR/260B DOF/240101 REG/VHEBO EET/YBBB0103 SEL/CEFS CODE/7C5325 OPR/QFA ORGN/YSSYQFAO PER/C /V/">KAMPI6/16R WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 RNVD1A1 SUR/260B DOF/240101 REG/VHEBO EET/YBBB0103 SEL/CEFS CODE/7C5325 OPR/QFA ORGN/YSSYQFAO PER/C /V/">KAMPI6/16R WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
         <TimedMessage Time="300" Message="Takeoff" />
       </TimedMessages>
@@ -3478,8 +3478,8 @@
       <Squawk Code="2377" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.951944" Longitude="151.188889" Speed="0" Altitude="16" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVFU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">ABBEY3/16L WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVFU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">ABBEY3/16L WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
         <TimedMessage Time="240" Message="SY ADC to SY DEP Coord: 'Next, Runway 16L, JST531'" />
         <TimedMessage Time="300" Message="Set Level to Coordinated instruction, and Takeoff" />
@@ -3501,8 +3501,8 @@
       <Squawk Code="7106" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.951944" Longitude="151.188889" Speed="0" Altitude="16" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDFGHRYZ/LB1" Rules="I" CruiseSpeed="405" ETD="0000" ATD="0000" RFL="260" EETHours="1" EETMins="25" FuelHours="2" FuelMins="30" Remarks="PBN/A1B2C2D2O2 NAV/RNP2 DOF/220501 REG/VHNJI EET/YBBB0002 CODE/7C431C OPR/NATIONAL JET SYSTEMS PER/C /V/">ABBEY3/16L WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDFGHRYZ/LB1" Rules="I" CruiseSpeed="405" ETD="0000" ATD="0000" RFL="260" EETHours="1" EETMins="25" FuelHours="2" FuelMins="30" Remarks="PBN/A1B2C2D2O2 NAV/RNP2 DOF/220501 REG/VHNJI EET/YBBB0002 CODE/7C431C OPR/NATIONAL JET SYSTEMS PER/C /V/">ABBEY3/16L WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
         <TimedMessage Time="340" Message="SY ADC to SY DEP Coord: 'Next, Runway 16L, JTE7445'" />
         <TimedMessage Time="400" Message="Set Level to Coordinated instruction, and Takeoff" />
@@ -3513,8 +3513,8 @@
       <Squawk Code="3765" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.930278" Longitude="151.171667" Speed="0" Altitude="7" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1L1O1S2 NAV/RNP2 DOF/240101 REG/VHRQP SEL/CEDQ CODE/7C585F OPR/RXA ORGN/KAUSFFLX PER/C /V/">KAMPI6/16R WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1L1O1S2 NAV/RNP2 DOF/240101 REG/VHRQP SEL/CEDQ CODE/7C585F OPR/RXA ORGN/KAUSFFLX PER/C /V/">KAMPI6/16R WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
         <TimedMessage Time="600" Message="Takeoff" />
       </TimedMessages>
@@ -3533,8 +3533,8 @@
       <Squawk Code="6610" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.951944" Longitude="151.188889" Speed="0" Altitude="16" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">ABBEY3/16L WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">ABBEY3/16L WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
 		    <TimedMessage Time="300" Message="Activate Plan" />
         <TimedMessage Time="840" Message="SY ADC to SY DEP Coord: 'Next, Runway 16L, VOZ876'" />
@@ -3545,8 +3545,8 @@
       <Squawk Code="3227" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.930278" Longitude="151.171667" Speed="0" Altitude="7" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYQC SEL/FRBM OPR/AIR AUSTRALIA PER/C RMK/TCAS EQUIPPED CALLSIGN STRATEGIC /V/ ">KAMPI6/16R WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYQC SEL/FRBM OPR/AIR AUSTRALIA PER/C RMK/TCAS EQUIPPED CALLSIGN STRATEGIC /V/ ">KAMPI6/16R WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
 		<TimedMessage Time="340" Message="Activate Plan" />
         <TimedMessage Time="940" Message="Takeoff" />
@@ -3556,8 +3556,8 @@
       <Squawk Code="6422" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.930278" Longitude="151.171667" Speed="0" Altitude="7" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Equipment="SBDE2E3FGHIJ1J3J4J5M1M3P2RWXYZ/LB1D1G1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="430" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="STS/HEAD STATE PBN/A1B2C2D2L1S2 NAV/RNP2 DOF/240101 REG/A56003 OPR/RAAF PER/C RMK/TCAS EQUIPPED /V/ ">KAMPI6/16R WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Equipment="SBDE2E3FGHIJ1J3J4J5M1M3P2RWXYZ/LB1D1G1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="430" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="STS/HEAD STATE PBN/A1B2C2D2L1S2 NAV/RNP2 DOF/240101 REG/A56003 OPR/RAAF PER/C RMK/TCAS EQUIPPED /V/ ">KAMPI6/16R WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
 		<TimedMessage Time="450" Message="Activate Plan" />
         <TimedMessage Time="1050" Message="Takeoff" />
@@ -3567,8 +3567,8 @@
       <Squawk Code="0074" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.951944" Longitude="151.188889" Speed="0" Altitude="16" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">ABBEY3/16L WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">ABBEY3/16L WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
 		    <TimedMessage Time="500" Message="Activate Plan" />
         <TimedMessage Time="1040" Message="SY ADC to SY DEP Coord: 'Next, Runway 16L, QFA483'" />
@@ -3579,8 +3579,8 @@
       <Squawk Code="4334" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.930278" Longitude="151.171667" Speed="0" Altitude="7" />
-      <FlightPlan Departure="YSSY" Destination="YMAV" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="30" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVFU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">KAMPI6/16R WOL H65 RAZZI Q29 ML DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML AV</Route>
+      <FlightPlan Departure="YSSY" Destination="YMAV" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="30" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVFU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">KAMPI6/16R WOL H65 LEECE Q29 ML DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML AV</Route>
 	  <TimedMessages>
 	    <TimedMessage Time="560" Message="Activate Plan" />
         <TimedMessage Time="1160" Message="Takeoff" />
@@ -3612,8 +3612,8 @@
       <Squawk Code="3402" ModeC="true" />
       <Cleared Level="5000" Approach="false" />
       <Position Latitude="-33.930278" Longitude="151.171667" Speed="0" Altitude="7" />
-      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">KAMPI6/16R WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
-      <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
+      <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">KAMPI6/16R WOL H65 LEECE Q29 LIZZI DCT</FlightPlan>
+      <Route>WOL LEECE TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
 		<TimedMessage Time="1900" Message="Activate Plan" />
         <TimedMessage Time="2500" Message="Takeoff" />
@@ -5052,7 +5052,7 @@
             <Position Latitude="-34.28694" Longitude="151.096398" Speed="340" Altitude="20000" />
             <Cleared Level="20000" />
             <FlightPlan Active="true" Departure="YSSY" Destination="YSCB" Alternative="" Rules="I" CruiseSpeed="0" ETD="0000" ATD="0000" RFL="20000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="REG/VHVHF PER/C OPR/VOZ VIRTUAL NAV/RNP10 GPSRNAV RMK/TCAS EQUIPPED /v/">DCT TESAT H65 CB DCT</FlightPlan>
-            <Route>WOL RAZZI</Route>
+            <Route>WOL LEECE</Route>
           </Aircraft>
           <Aircraft Callsign="YMA03" Type="B738" Delay="0">
             <Squawk Code="4122" ModeC="true" />
@@ -5072,8 +5072,8 @@
             <Squawk Code="3177" ModeC="true" />
             <Position Latitude="-34.391667" Longitude="150.959722" Speed="370" Altitude="24500" />
             <Cleared Level="28000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="18" FuelHours="0" FuelMins="0" Remarks="/v/">DCT TESAT H65 RAZZI Q29 ML DCT</FlightPlan>
-            <Route>RAZZI TANTA RUMIE NABBA BULLA LIZZI</Route>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="18" FuelHours="0" FuelMins="0" Remarks="/v/">DCT TESAT H65 LEECE Q29 ML DCT</FlightPlan>
+            <Route>LEECE TANTA RUMIE NABBA BULLA LIZZI</Route>
           </Aircraft>
           <Aircraft Callsign="EVY701" Type="B737" Delay="0">
             <Squawk Code="4452" ModeC="true" />
@@ -5135,7 +5135,7 @@
 
         **AM213** and **QLK2039D** should be taken off around the same time (You will be prompted). This will cause an enroute conflict at TEMIS.  
 
-        **QLK2039D** arrives around the same time as the cluster from YSSY, up to your student whether to sequence it in the middle or the end. 
+        **QLK39D** arrives around the same time as the cluster from YSSY, up to your student whether to sequence it in the middle or the end. 
 
         A steady flow of aircraft will be departing YMML for YSSY/YSBK. The first and second departures (**TFX11** and **TFR44**) are both slower so some sequencing will be required on their way to YSSY.  
 
@@ -5147,52 +5147,52 @@
         <Targets>
           <Aircraft Callsign="VOZ443" Type="B738" Delay="0">
             <Squawk Code="4111" ModeC="true" />
-            <Cleared Level="36000" />
-            <Position Latitude="-35.273154" Longitude="149.582247" Speed="460" Altitude="36000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="250" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 RAZZI Q29 ML</FlightPlan>
+            <Cleared Level="32000" />
+            <Position Latitude="-35.273154" Longitude="149.582247" Speed="460" Altitude="32000" />
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="250" ETD="0000" ATD="0000" RFL="32000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 LEECE Q29 ML</FlightPlan>
             <Route>TANTA RUMIE NABBA BULLA LUVAS LIZZI</Route>
           </Aircraft>
           <Aircraft Callsign="QFA864" Type="B738" Delay="0">
             <Squawk Code="4423" ModeC="true" />
             <Cleared Level="38000" />
             <Position Latitude="-35.262598" Longitude="149.601871" Speed="460" Altitude="38000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="250" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 RAZZI Q29 ML</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="250" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 LEECE Q29 ML</FlightPlan>
             <Route>TANTA RUMIE NABBA BULLA LUVAS LIZZI</Route>
           </Aircraft>
           <Aircraft Callsign="RXA44" Type="B738" Delay="0">
             <Squawk Code="4122" ModeC="true" />
             <Cleared Level="36000" />
             <Position Latitude="-35.23436099999999" Longitude="149.65077" Speed="490" Altitude="36000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="280" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 RAZZI Q29 ML</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="280" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 LEECE Q29 ML</FlightPlan>
             <Route>TANTA RUMIE NABBA BULLA LUVAS LIZZI</Route>
           </Aircraft>
           <Aircraft Callsign="JST677" Type="A320" Delay="0">
             <Squawk Code="4113" ModeC="true" />
             <Cleared Level="34000" />
             <Position Latitude="-35.169985" Longitude="149.761011" Speed="460" Altitude="34000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="250" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 RAZZI Q29 ML</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="250" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 LEECE Q29 ML</FlightPlan>
             <Route>TANTA RUMIE NABBA BULLA LUVAS LIZZI</Route>
           </Aircraft>
           <Aircraft Callsign="UAL4" Type="B789" Delay="0">
             <Squawk Code="1351" ModeC="true" />
             <Cleared Level="40000" />
             <Position Latitude="-35.031708" Longitude="150.000766" Speed="510" Altitude="40000" />
-            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="290" ETD="0000" ATD="0000" RFL="40000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 RAZZI Q29 ML</FlightPlan>
+            <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="290" ETD="0000" ATD="0000" RFL="40000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 LEECE Q29 ML</FlightPlan>
             <Route>TANTA RUMIE NABBA BULLA LUVAS LIZZI</Route>
           </Aircraft>
           <Aircraft Callsign="BNZ23" Type="B38M" Delay="0">
             <Squawk Code="1541" ModeC="true" />
             <Cleared Level="36000" />
             <Position Latitude="-34.870014" Longitude="150.273038" Speed="460" Altitude="36000" />
-            <FlightPlan Active="true" Departure="YWLM" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="250" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 RAZZI Q29 ML</FlightPlan>
-            <Route>RAZZI TANTA RUMIE NABBA BULLA LUVAS LIZZI</Route>
+            <FlightPlan Active="true" Departure="YWLM" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="250" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">WOL H65 LEECE Q29 ML</FlightPlan>
+            <Route>LEECE TANTA RUMIE NABBA BULLA LUVAS LIZZI</Route>
           </Aircraft>
           <Aircraft Callsign="EVY30" Type="CL60" Delay="30" StartAuto="true">
             <Squawk Code="5234" ModeC="true" />
             <Cleared Level="24000" />
             <Position Latitude="-35.290894" Longitude="149.194461" Speed="1" Altitude="1886" />
             <FlightPlan Active="true" Departure="YSCB" Destination="YMAV" Alternative="" Rules="I" CruiseSpeed="240" ETD="0000" ATD="0000" RFL="43000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TANTA2/17 TANTA Q29 ML JAYBI</FlightPlan>
-            <Route>BIDGI KELLY TANTA RUMIE NABBA BULLA LUVAS LIZZI</Route>
+            <Route>TANTA RUMIE NABBA BULLA LUVAS LIZZI</Route>
           </Aircraft>
           <Aircraft Callsign="AM213" Type="BE20" Delay="0">
             <Squawk Code="2000" ModeC="false" />
@@ -5253,8 +5253,8 @@
             <Squawk Code="2342" ModeC="true" />
             <Cleared Level="23000" />
             <Position Latitude="-37.655713" Longitude="144.835419" Speed="1" Altitude="427" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSBK" Alternative="" Rules="I" CruiseSpeed="220" ETD="0000" ATD="0000" RFL="23000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DOSEL1/16 DOSEL Y59 CULIN WATLE Y20 BK</FlightPlan>
-            <Route>DOSEL EBONY ARRAN NONUP CULIN WATLE</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSBK" Alternative="" Rules="I" CruiseSpeed="220" ETD="0000" ATD="0000" RFL="23000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DOSEL1/16 DOSEL Y59 CULIN DCT AKMIR W817 DARGI Y20 BK DCT</FlightPlan>
+            <Route>DOSEL EBONY ARRAN NONUP CULIN AKMIR DARGI ANPEN GOMUB NOLEM</Route>
           </Aircraft>
           <Aircraft Callsign="QFA64" Type="B789" Delay="0">
             <Squawk Code="7213" ModeC="true" />

--- a/ScenarioFiles.xml
+++ b/ScenarioFiles.xml
@@ -4905,7 +4905,7 @@
             <FlightPlan Departure="YBLN" Destination="YMML" Alternative="" Active="false" Rules="I" CruiseSpeed="453" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT BLN DCT PAVSO DCT NIPON DCT VIMUS Y53 WENDY DCT </FlightPlan>
             <Route>PAVSO NIPON VIMUS</Route>
             <TimedMessages>
-              <TimedMessage Time="1560" Message="JST901, IFR A320, Taxis Busselton for Melbourne, Runway 03" />
+              <TimedMessage Time="1650" Message="JST901, IFR A320, Taxis Busselton for Melbourne, Runway 03" />
               <TimedMessage Time="1920" Message="Select Runway 03, Climb to F125, and Takeoff" />
             </TimedMessages>
           </Aircraft>
@@ -4920,15 +4920,15 @@
             <Squawk Code="3102" ModeC="true" />
             <Cleared Level="14000" />
             <Position Latitude="-33.72" Longitude="121.65000000000002" Speed="0" Altitude="14000" />
-            <FlightPlan Departure="YESP" Destination="YABA" Alternative="" Active="true" Rules="I" CruiseSpeed="265" ETD="0000" ATD="0000" RFL="14000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT HOODY YABA DCT</FlightPlan>
-            <Route>HOODY</Route>
+            <FlightPlan Departure="YESP" Destination="YABA" Alternative="" Active="true" Rules="I" CruiseSpeed="265" ETD="0000" ATD="0000" RFL="14000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ESP W486 ABA DCT</FlightPlan>
+            <Route>HOODY ABA YABA</Route>
           </Aircraft>
           <Aircraft Callsign="FD672" Type="PC12" Delay="0">
             <Squawk Code="2000" ModeC="true" />
             <Cleared Level="17000" />
             <Position Latitude="-34.943299999999994" Longitude="117.8088" Speed="0" Altitude="223" />
-            <FlightPlan Departure="YABA" Destination="YESP" Alternative="" Active="false" Rules="I" CruiseSpeed="260" ETD="0000" ATD="0000" RFL="17000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">YBLN/14 HOODY DCT</FlightPlan>
-            <Route>HOODY</Route>
+            <FlightPlan Departure="YABA" Destination="YESP" Alternative="" Active="false" Rules="I" CruiseSpeed="260" ETD="0000" ATD="0000" RFL="17000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ABA W486 ESP DCT</FlightPlan>
+            <Route>HOODY ESP YESP</Route>
             <TimedMessages>
               <TimedMessage Time="60" Message="FD672, IFR PC12, Taxis Albany for Esperence, Runway 14." />
               <TimedMessage Time="480" Message="Select Runway 14, Climb to F125, and Takeoff" />
@@ -4938,7 +4938,7 @@
             <Squawk Code="2000" ModeC="true" />
             <Position Latitude="-34.943299999999994" Longitude="117.8088" Speed="0" Altitude="223" />
             <Cleared Level="10000" />
-            <FlightPlan Departure="YABA" Destination="YBLN" Alternative="" Active="false" Rules="I" CruiseSpeed="150" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">YBLN/14 YBLN DCT</FlightPlan>
+            <FlightPlan Departure="YABA" Destination="YBLN" Alternative="" Active="false" Rules="I" CruiseSpeed="150" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ABA BLN DCT</FlightPlan>
             <Route>BLN YBLN</Route>
             <TimedMessages>
               <TimedMessage Time="60" Message="PIG, IFR Cessna 210, Taxis Albany for Busselton, Runway 14." />
@@ -4950,7 +4950,7 @@
             <Cleared Level="41000" />
             <Position Latitude="-27.33" Longitude="108.466" Speed="450" Altitude="41000" />
             <FlightPlan Departure="OMDB" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="481" ETD="0000" ATD="0000" RFL="41000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT KITAL L894 MERIB T12 IPMOR DCT</FlightPlan>
-            <Route>MERIB OPEGA KAGMI</Route>
+            <Route>MERIB OPEGA KAGMI KALBO IPMOR</Route>
           </Aircraft>
           <Aircraft Callsign="QTR901" Type="A388" Delay="1860" StartAuto="true">
             <Squawk Code="6456" ModeC="true" />
@@ -4983,7 +4983,7 @@
           <Aircraft Callsign="NWK1613" Type="A320" Delay="0">
             <Squawk Code="2000" ModeC="false" />
             <Position Latitude="-28.796" Longitude="114.70750000000001" Speed="0" Altitude="115" />
-            <FlightPlan Departure="YGEL" Destination="YPPH" Alternative="" Active="false" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="27000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT GEL DCT HINDS Q38 JULIM </FlightPlan>
+            <FlightPlan Departure="YGEL" Destination="YPPH" Alternative="" Active="false" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="27000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT GEL DCT HINDS Q38 JULIM DCT</FlightPlan>
             <Route>HINDS CALIG JULIM</Route>
             <TimedMessages>
               <TimedMessage Time="840" Message="NWK1613, IFR A320, Taxis Geraldton for Perth, Runway 03" />
@@ -5133,7 +5133,7 @@
 
         **ASY10** cuts straight through the YSSY/YMML airway at BULLA, just to add more mayhem.  
 
-        **AM213** and **QLK2039D** should be taken off around the same time (You will be prompted). This will cause an enroute conflict at TEMIS.  
+        **AM213** and **QLK39D** should be taken off around the same time (You will be prompted). This will cause an enroute conflict at TEMIS.  
 
         **QLK39D** arrives around the same time as the cluster from YSSY, up to your student whether to sequence it in the middle or the end. 
 

--- a/ScenarioFiles.xml
+++ b/ScenarioFiles.xml
@@ -1172,7 +1172,7 @@
       <Aircraft Callsign="QFA889" Type="B738" Delay="0" StartAuto="false">
         <Squawk Code="0" ModeC="false" />
         <Position Latitude="-34.939807" Longitude="138.537748" Speed="0" Altitude="33" />
-        <FlightPlan Departure="YPAD" Destination="YPPH" Alternative="" Active="false" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="36000" EETHours="3" EETMins="15" FuelHours="4" FuelMins="50" Remarks="NAV/RNP2 RTF/QANTAS /v/">DCT GILES Q33 ESP Q158 BEVLY DCT</FlightPlan>
+        <FlightPlan Departure="YPAD" Destination="YPPH" Alternative="" Active="false" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="36000" EETHours="3" EETMins="15" FuelHours="4" FuelMins="50" Remarks="NAV/RNP2 RTF/QANTAS /v/">DCT GILES Q33 ESP Q158 KABLI DCT</FlightPlan>
         <Route>COLPY</Route>
         <TimedMessages>
           <TimedMessage Time="180" Message="Request Clearance to Perth (Bay 21)" />
@@ -1183,7 +1183,7 @@
       <Aircraft Callsign="VOZ441" Type="B738" Delay="0" StartAuto="false">
         <Squawk Code="0" ModeC="false" />
         <Position Latitude="-34.93780799999999" Longitude="138.54068300000003" Speed="0" Altitude="33" />
-        <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="false" Rules="I" CruiseSpeed="452" ETD="0000" ATD="0000" RFL="39000" EETHours="1" EETMins="57" FuelHours="3" FuelMins="07" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT PANKI H247 CULIN Y59 RIVET DCT</FlightPlan>
+        <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="false" Rules="I" CruiseSpeed="452" ETD="0000" ATD="0000" RFL="39000" EETHours="1" EETMins="57" FuelHours="3" FuelMins="07" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT AVDEN H247 CULIN Y59 RIVET DCT</FlightPlan>
         <Route>COLPY</Route>
         <TimedMessages>
           <TimedMessage Time="360" Message="Request Clearance to Sydney (Bay 13)" />
@@ -1225,7 +1225,7 @@
       <Aircraft Callsign="QFA1950" Type="E190" Delay="240" StartAuto="true">
         <Squawk Code="0" ModeC="false" />
         <Position Latitude="-34.941057" Longitude="138.535877" Speed="0" Altitude="33" />
-        <FlightPlan Departure="YPAD" Destination="YPDN" Alternative="" Active="false" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="34000" EETHours="4" EETMins="02" FuelHours="6" FuelMins="02" Remarks="NAV/RNP2 RTF/QANTAS /v/">DCT HAWKY J58 WHA J251 GREGA/M078F360 J251 TN Q23 VEGPU DCT </FlightPlan>
+        <FlightPlan Departure="YPAD" Destination="YPDN" Alternative="" Active="false" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="34000" EETHours="4" EETMins="02" FuelHours="6" FuelMins="02" Remarks="NAV/RNP2 RTF/QANTAS /v/">DCT AREPA J58 WHA J251 GREGA/M078F360 J251 TN Q23 VEGPU DCT </FlightPlan>
         <Route>COLPY</Route>
         <TimedMessages>
           <TimedMessage Time="810" Message="Request Clearance to Darwin (Bay 26)" />
@@ -1236,7 +1236,7 @@
       <Aircraft Callsign="FD578" Type="PC12" Delay="660" StartAuto="true">
         <Squawk Code="0" ModeC="false" />
         <Position Latitude="-34.95057" Longitude="138.52138700000003" Speed="0" Altitude="23" />
-        <FlightPlan Departure="YPAD" Destination="YLOX" Alternative="" Active="false" Rules="I" CruiseSpeed="268" ETD="0000" ATD="0000" RFL="15000" EETHours="00" EETMins="34" FuelHours="3" FuelMins="00" Remarks="NAV/RNP2 RTF/FLYDOC /v/">DCT AD V361 SEDAN DCT </FlightPlan>
+        <FlightPlan Departure="YPAD" Destination="YLOX" Alternative="" Active="false" Rules="I" CruiseSpeed="268" ETD="0000" ATD="0000" RFL="15000" EETHours="00" EETMins="34" FuelHours="3" FuelMins="00" Remarks="NAV/RNP2 RTF/FLYDOC /v/">DCT AD V361 UPROT DCT </FlightPlan>
         <Route>COLPY</Route>
         <TimedMessages>
           <TimedMessage Time="1230" Message="Request Clearance to Loxton" />
@@ -1246,7 +1246,7 @@
       <Aircraft Callsign="QFA734" Type="B738" Delay="840" StartAuto="true">
         <Squawk Code="0" ModeC="false" />
         <Position Latitude="-34.940313" Longitude="138.536973" Speed="0" Altitude="33" />
-        <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="false" Rules="I" CruiseSpeed="452" ETD="0000" ATD="0000" RFL="37000" EETHours="1" EETMins="48" FuelHours="2" FuelMins="59" Remarks="NAV/RNP2 RTF/QANTAS /v/">DCT PANKI H247 CULIN Y59 RIVET DCT</FlightPlan>
+        <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="false" Rules="I" CruiseSpeed="452" ETD="0000" ATD="0000" RFL="37000" EETHours="1" EETMins="48" FuelHours="2" FuelMins="59" Remarks="NAV/RNP2 RTF/QANTAS /v/">DCT AVDEN H247 CULIN Y59 RIVET DCT</FlightPlan>
         <Route>COLPY</Route>
         <TimedMessages>
           <TimedMessage Time="1440" Message="Request Clearance to Sydney (Bay 23)" />
@@ -1285,7 +1285,7 @@
       <Aircraft Callsign="VOZ1407" Type="B738" Delay="1980" StartAuto="true">
         <Squawk Code="0" ModeC="false" />
         <Position Latitude="-34.938591" Longitude="138.5396" Speed="0" Altitude="33" />
-        <FlightPlan Departure="YPAD" Destination="YBBN" Alternative="" Active="false" Rules="I" CruiseSpeed="432" ETD="0000" ATD="0000" RFL="39000" EETHours="2" EETMins="10" FuelHours="3" FuelMins="37" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT SEDAN Y465 ENLIP DCT </FlightPlan>
+        <FlightPlan Departure="YPAD" Destination="YBBN" Alternative="" Active="false" Rules="I" CruiseSpeed="432" ETD="0000" ATD="0000" RFL="39000" EETHours="2" EETMins="10" FuelHours="3" FuelMins="37" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT UPROT Y465 ENLIP DCT </FlightPlan>
         <Route>COLPY</Route>
         <TimedMessages>
           <TimedMessage Time="2580" Message="Request Clearance to Brisbane (Bay 16)" />
@@ -1357,7 +1357,7 @@
         <Squawk Code="3007" ModeC="true" />
         <Cleared Approach="true" />
         <Position Latitude="-34.78833333" Longitude="136.71527778" Speed="200" Altitude="3000" />
-        <FlightPlan Departure="YPPH" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="37000" EETHours="2" EETMins="28" FuelHours="3" FuelMins="58" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT HECTO Y135 ROGAS Y39 RIKAB RIKA8A/23</FlightPlan>
+        <FlightPlan Departure="YPPH" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="37000" EETHours="2" EETMins="28" FuelHours="3" FuelMins="58" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT HECTO Y135 DADRU Y39 RIKAB RIKA8A/23</FlightPlan>
         <Route>RIKAB</Route>
       </Aircraft>
       <Aircraft Callsign="JST961" Type="A320" Delay="0" StartAuto="true">
@@ -1687,15 +1687,15 @@
                 <Squawk Code="2421" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.94043800000001" Longitude="138.542781" Speed="1" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="320" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">PANKI3/23 PANKI H247 CULIN Y59 TESAT</FlightPlan>
-                <Route>PANKI BOLAM NATYA TOBOB CULIN TARAL RIVET TESAT</Route>
+                <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="320" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">AVDEN1/23 AVDEN H247 CULIN Y59 TESAT</FlightPlan>
+                <Route>AVDEN BOLAM NATYA TOBOB CULIN TARAL RIVET TESAT</Route>
             </Aircraft>
             <Aircraft Callsign="QFA723" Type="B738" Delay="0">
                 <Squawk Code="4123" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.940456" Longitude="138.542781" Speed="0" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YBAS" Alternative="" Active="true" Rules="I" CruiseSpeed="435" ETD="0000" ATD="0000" RFL="340" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">HAWKY5/23 HAWKY J58 WHA J251 AS</FlightPlan>
-                <Route>HAWKY SPOTA WHA OJJAY WR</Route>
+                <FlightPlan Departure="YPAD" Destination="YBAS" Alternative="" Active="true" Rules="I" CruiseSpeed="435" ETD="0000" ATD="0000" RFL="340" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">AREPA1/23 AREPA J58 WHA J251 AS</FlightPlan>
+                <Route>AREPA SPOTA WHA OJJAY WR</Route>
                 <TimedMessages>
                     <TimedMessage Time="720" Message="Takeoff" />
                 </TimedMessages>
@@ -1704,7 +1704,7 @@
                 <Squawk Code="2251" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.940449" Longitude="138.542794" Speed="0" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="330" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO2/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
+                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="330" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO3/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
                 <Route>BENDO RELEP LULTO APPLE ARBEY ML</Route>
                 <TimedMessages>
                     <TimedMessage Time="1100" Message="Takeoff" />
@@ -1714,7 +1714,7 @@
                 <Squawk Code="3151" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.940442999999995" Longitude="138.542773" Speed="0" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="" Active="true" Rules="I" CruiseSpeed="400" ETD="0000" ATD="0000" RFL="350" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO2/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
+                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="" Active="true" Rules="I" CruiseSpeed="400" ETD="0000" ATD="0000" RFL="350" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO3/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
                 <Route>BENDO RELEP LULTO APPLE ARBEY ML</Route>
                 <TimedMessages>
                     <TimedMessage Time="2100" Message="Takeoff" />
@@ -1727,15 +1727,15 @@
                 <FlightPlan Departure="YPAD" Destination="YKSC" Alternative="" Active="true" Rules="I" CruiseSpeed="190" ETD="0000" ATD="0000" RFL="8000" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">AD4/23 AD EEMUE VAVPA DCT</FlightPlan>
                 <Route>EEMUE VAVPA</Route>
                 <TimedMessages>
-                    <TimedMessage Time="360" Message="Next, URT" />
-                    <TimedMessage Time="420" Message="Takeoff (Ensure Coordinated Heading/Level is set)" />
+                    <TimedMessage Time="360" Message="AD ADC to AD APP Coord: 'Next, URT'" />
+                    <TimedMessage Time="420" Message="Set Heading and Level to Coordinated instruction, and Takeoff" />
                 </TimedMessages>
             </Aircraft>
             <Aircraft Callsign="QFA6112" Type="B744" Delay="0">
                 <Squawk Code="4412" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.94044399999999" Longitude="138.542781" Speed="0" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="" Active="true" Rules="I" CruiseSpeed="510" ETD="0000" ATD="0000" RFL="350" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO2/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
+                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="" Active="true" Rules="I" CruiseSpeed="510" ETD="0000" ATD="0000" RFL="350" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO3/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
                 <Route>BENDO RELEP LULTO APPLE ARBEY ML</Route>
                 <TimedMessages>
                     <TimedMessage Time="2200" Message="Takeoff" />
@@ -1780,8 +1780,8 @@
                 <Squawk Code="2121" ModeC="true" />
                 <Cleared Level="9000" />
                 <Position Latitude="-34.551179000000005" Longitude="132.218293" Speed="450" Altitude="45000" />
-                <FlightPlan Departure="YPPH" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="480" ETD="0000" ATD="0000" RFL="45000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PH H18 BURGU Y135 ROGAS Y39 RIKAB RIKA8A/23</FlightPlan>
-                <Route>TUTNO ROGAS RIKAB RWY23</Route>
+                <FlightPlan Departure="YPPH" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="480" ETD="0000" ATD="0000" RFL="45000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PH H18 BURGU Y135 DADRU Y39 RIKAB RIKA8A/23</FlightPlan>
+                <Route>TUTNO DADRU RIKAB RWY23</Route>
             </Aircraft>
             <Aircraft Callsign="JST682" Type="A320" Delay="0" StartAuto="true">
                 <Squawk Code="4121" ModeC="true" />
@@ -1858,15 +1858,15 @@
                 <Squawk Code="2421" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.94043800000001" Longitude="138.542781" Speed="1" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="YSCB" Active="true" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="330" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">PANKI3/23 PANKI H247 CULIN Y59 TESAT</FlightPlan>
-                <Route>PANKI BOLAM NATYA TOBOB CULIN TARAL RIVET TESAT</Route>
+                <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="YSCB" Active="true" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="330" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">AVDEN1/23 AVDEN H247 CULIN Y59 TESAT</FlightPlan>
+                <Route>AVDEN BOLAM NATYA TOBOB CULIN TARAL RIVET TESAT</Route>
             </Aircraft>
             <Aircraft Callsign="QFA723" Type="B738" Delay="0">
                 <Squawk Code="4123" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.940456" Longitude="138.542781" Speed="0" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YBAS" Alternative="YAYE" Active="true" Rules="I" CruiseSpeed="435" ETD="0000" ATD="0000" RFL="340" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">HAWKY5/23 HAWKY J58 WHA J251 AS</FlightPlan>
-                <Route>HAWKY SPOTA WHA OJJAY WR</Route>
+                <FlightPlan Departure="YPAD" Destination="YBAS" Alternative="YAYE" Active="true" Rules="I" CruiseSpeed="435" ETD="0000" ATD="0000" RFL="340" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">AREPA1/23 AREPA J58 WHA J251 AS</FlightPlan>
+                <Route>AREPA SPOTA WHA OJJAY WR</Route>
                 <TimedMessages>
                     <TimedMessage Time="660" Message="Takeoff" />
                 </TimedMessages>
@@ -1875,7 +1875,7 @@
                 <Squawk Code="2251" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.940449" Longitude="138.542794" Speed="0" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YPAD" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="330" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO2/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
+                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YPAD" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="330" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO3/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
                 <Route>BENDO RELEP LULTO APPLE ARBEY ML</Route>
                 <TimedMessages>
                     <TimedMessage Time="240" Message="Takeoff" />
@@ -1885,8 +1885,8 @@
                 <Squawk Code="3122" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.940445" Longitude="138.542763" Speed="0" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YPPH" Alternative="YPKG" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="340" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">HAWKY5/23 HAWKY H54 KAMBI Q32 NODEV Q10 HAMTN Q158 BEVLY DCT</FlightPlan>
-                <Route>HAWKY KAMBI ISRED ALBIX SUPAS DUNDA NODEV HAMTN BEVLY</Route>
+                <FlightPlan Departure="YPAD" Destination="YPPH" Alternative="YPKG" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="340" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">AREPA1/23 AREPA H54 KAMBI Q32 NODEV Q10 MALUP Q158 KABLI DCT</FlightPlan>
+                <Route>AREPA KAMBI ISRED ALBIX SUPAS DUNDA NODEV MALUP KABLI</Route>
                 <TimedMessages>
                     <TimedMessage Time="420" Message="Takeoff" />
                 </TimedMessages>
@@ -1895,7 +1895,7 @@
                 <Squawk Code="3151" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.940442999999995" Longitude="138.542773" Speed="0" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YMEN" Active="true" Rules="I" CruiseSpeed="400" ETD="0000" ATD="0000" RFL="350" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO2/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
+                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YMEN" Active="true" Rules="I" CruiseSpeed="400" ETD="0000" ATD="0000" RFL="350" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO3/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
                 <Route>BENDO RELEP LULTO APPLE ARBEY ML</Route>
                 <TimedMessages>
                     <TimedMessage Time="1620" Message="Takeoff" />
@@ -1908,15 +1908,15 @@
                 <FlightPlan Departure="YPAD" Destination="YKSC" Alternative="YPAD" Active="true" Rules="I" CruiseSpeed="190" ETD="0000" ATD="0000" RFL="8000" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">AD4/23 AD V504 VAVPA DCT</FlightPlan>
                 <Route>EEMUE VAVPA</Route>
                 <TimedMessages>
-                    <TimedMessage Time="1190" Message="Coord TWR to TCU. Next, URT, Runway 23." />
-                    <TimedMessage Time="1260" Message="Takeoff" />
+                    <TimedMessage Time="1190" Message="AD ADC to AD APP Coord: 'Next, URT'" />
+                    <TimedMessage Time="1260" Message="Set Heading and Level to Coordinated instruction, and Takeoff" />
                 </TimedMessages>
             </Aircraft>
             <Aircraft Callsign="QFA6112" Type="B744" Delay="0">
                 <Squawk Code="4412" ModeC="true" />
                 <Cleared Level="5000" />
                 <Position Latitude="-34.94044399999999" Longitude="138.542781" Speed="0" Altitude="36" />
-                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YMEN" Active="true" Rules="I" CruiseSpeed="510" ETD="0000" ATD="0000" RFL="350" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO2/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
+                <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YMEN" Active="true" Rules="I" CruiseSpeed="510" ETD="0000" ATD="0000" RFL="350" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO3/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
                 <Route>BENDO RELEP LULTO APPLE ARBEY ML</Route>
                 <TimedMessages>
                     <TimedMessage Time="2160" Message="Takeoff" />
@@ -1970,8 +1970,8 @@
                 <Squawk Code="2121" ModeC="true" />
                 <Cleared Level="9000" />
                 <Position Latitude="-34.551179000000005" Longitude="132.918293" Speed="450" Altitude="45000" />
-                <FlightPlan Departure="YPPH" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="480" ETD="0000" ATD="0000" RFL="45000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PH H18 BURGU Y135 ROGAS Y39 RIKAB RIKA8A/23</FlightPlan>
-                <Route>TUTNO ROGAS RIKAB RWY23</Route>
+                <FlightPlan Departure="YPPH" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="480" ETD="0000" ATD="0000" RFL="45000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PH H18 BURGU Y135 DADRU Y39 RIKAB RIKA8A/23</FlightPlan>
+                <Route>TUTNO DADRU RIKAB RWY23</Route>
             </Aircraft>
             <Aircraft Callsign="JST682" Type="A320" Delay="0" StartAuto="true">
                 <Squawk Code="4121" ModeC="true" />
@@ -1986,9 +1986,6 @@
                 <Position Latitude="-34.543678" Longitude="139.474368" Speed="120" Altitude="4000" />
                 <FlightPlan Departure="YBHI" Destination="YGWA" Alternative="" Active="true" Rules="I" CruiseSpeed="120" ETD="0000" ATD="0000" RFL="4000" EETHours="02" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">DCT DISHA DCT</FlightPlan>
                 <Route>DISHA</Route>
-                <TimedMessages>
-                    <TimedMessage Time="480" Message="Coord ENR to TCU. East, WZA via DISHA" />
-                </TimedMessages>
             </Aircraft>
             <Aircraft Callsign="FDG" Type="PC12" Delay="0">
                 <Squawk Code="5112" ModeC="true" />
@@ -1997,18 +1994,18 @@
                 <FlightPlan Departure="YCEE" Destination="YGWA" Alternative="YPAD" Active="true" Rules="I" CruiseSpeed="230" ETD="0000" ATD="0000" RFL="15000" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">DCT SPENA V621 RIKAB N640 AD DCT</FlightPlan>
                 <Route>RIKAB AD YGWA</Route>
                 <TimedMessages>
-                    <TimedMessage Time="240" Message="ENR to TCU Coord. Two for you. via RIKAB, FDG, will be assigned F150. Additionally, RXA3458, for separation, will be assigned F160" />
+                    <TimedMessage Time="240" Message="TBD to AD APP Coord: 'Two for you. via RIKAB, FDG, will be assigned F150. Additionally, RXA3458, for separation, will be assigned F160'" />
                 </TimedMessages>
             </Aircraft>
             <Aircraft Callsign="AYZ" Type="PC12" Delay="0">
                 <Squawk Code="2000" ModeC="false" />
                 <Position Latitude="-35.481667" Longitude="138.751667" Speed="0" Altitude="66" />
-                <FlightPlan Departure="YGWA" Destination="YMLD" Alternative="" Active="false" Rules="I" CruiseSpeed="200" ETD="0000" ATD="0000" RFL="6000" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">DCT AD A585 HAWKY DCT</FlightPlan>
-                <Route>AD HAWKY YMLD</Route>
+                <FlightPlan Departure="YGWA" Destination="YMLD" Alternative="" Active="false" Rules="I" CruiseSpeed="200" ETD="0000" ATD="0000" RFL="6000" EETHours="01" EETMins="40" FuelHours="0" FuelMins="0" Remarks="/v/">DCT AD A585 AREPA DCT</FlightPlan>
+                <Route>AD AREPA YMLD</Route>
                 <TimedMessages>
                     <TimedMessage Time="240" Message="'Adelaide Approach, IFR PC12, AYZ, taxis Runway 19 Goolwa for Maitland'" />
-                    <TimedMessage Time="420" Message="Set Cleared level to 4500, and Takeoff" />
-                    <TimedMessage Time="600" Message="'AYZ, 5nm northwest of Goolwa, passing XXX, climbing to 6000ft, estimate Adelaide XXX'" />
+                    <TimedMessage Time="420" Message="Select Runway 19, Climb to A045, and Takeoff" />
+                    <TimedMessage Time="600" Message="'AYZ, Departure'" />
                 </TimedMessages>
             </Aircraft>
             <Aircraft Callsign="SRP" Type="C182" Delay="480" StartAuto="true">
@@ -2094,7 +2091,7 @@
               <Squawk Code="2210" ModeC="true" />
               <Position Latitude="-27.374982" Longitude="153.134136" Speed="1" Altitude="20" />
               <Cleared Level="6000" />
-              <FlightPlan Active="true" Departure="YBBN" Destination="YPPH" Alternative="" Rules="1" CruiseSpeed="445" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">SANEG1/19L SANEG Q4 PAVBI Q16 LOSPI DCT KADUV DCT WHA J21 MUBID Q10 HAMTN Q158 BEVLY DCT</FlightPlan>
+              <FlightPlan Active="true" Departure="YBBN" Destination="YPPH" Alternative="" Rules="1" CruiseSpeed="445" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">SANEG1/19L SANEG Q4 PAVBI Q16 LOSPI DCT KADUV DCT WHA J21 MUBID Q10 MALUP Q158 KABLI DCT</FlightPlan>
               <Route>SANEG OSTAM BOBOP</Route>
               <TimedMessages>
                 <TimedMessage Time="1370" Message="Takeoff" />
@@ -2137,8 +2134,8 @@
               <FlightPlan Active="true" Departure="YBBN" Destination="YBPN" Alternative="" Rules="1" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="24000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">BN4/19R BN V308 MK W387 PN DCT </FlightPlan>
               <Route>AKOBA SAGLI</Route>
               <TimedMessages>
-                <TimedMessage Time="20" Message="Coord. QLK2528, Next, 19R" />
-                <TimedMessage Time="110" Message="Takeoff" />
+                <TimedMessage Time="20" Message="BN ADC to BN APP Coord: 'Next, Runway 19R, QLK2528'" />
+                <TimedMessage Time="110" Message="Set Heading and Level to Coordinated instruction, and Takeoff" />
               </TimedMessages>
             </Aircraft>
             <Aircraft Callsign="QLK2406" Type="DH8C" Delay="0">
@@ -2148,8 +2145,8 @@
               <FlightPlan Active="true" Departure="YBBN" Destination="YEML" Alternative="" Rules="1" CruiseSpeed="337" ETD="0000" ATD="0000" RFL="18000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">BN4/19R BN Q484 MESED DCT LIKTO DCT UNVAT DCT EML DCT</FlightPlan>
               <Route>SAMVI RUDEY</Route>
               <TimedMessages>
-                <TimedMessage Time="1400" Message="Coord. QLK2406, next, 19R" />
-                <TimedMessage Time="1490" Message="Takeoff" />
+                <TimedMessage Time="1400" Message="BN ADC to BN APP Coord: 'Next, Runway 19R, QLK2406'" />
+                <TimedMessage Time="1490" Message="Set Heading and Level to Coordinated instruction, and Takeoff" />
               </TimedMessages>
             </Aircraft>
             <Aircraft Callsign="QLK2542" Type="DH8C" Delay="0">
@@ -2159,8 +2156,8 @@
               <FlightPlan Active="true" Departure="YBBN" Destination="YLRE" Alternative="" Rules="1" CruiseSpeed="337" ETD="0000" ATD="0000" RFL="24000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">BN4/19R BN Q484 LIKTO Q421 UNVAT W152 MOVBA W240 LRE DCT</FlightPlan>
               <Route>SAMVI RUDEY</Route>
               <TimedMessages>
-                <TimedMessage Time="920" Message="Coord. QLK2542, next Runway 19R" />
-                <TimedMessage Time="1010" Message="Takeoff" />
+                <TimedMessage Time="920" Message="BN ADC to BN APP Coord: 'Next, Runway 19R, QLK2542'" />
+                <TimedMessage Time="1010" Message="Set Heading and Level to Coordinated instruction, and Takeoff" />
               </TimedMessages>
             </Aircraft>
             <Aircraft Callsign="VOZ1497" Type="B737" Delay="0">
@@ -2254,7 +2251,7 @@
               <Squawk Code="4105" ModeC="true" />
               <Position Latitude="-28.22" Longitude="152.275" Speed="400" Altitude="25000" />
               <Cleared Level="3000" />
-              <FlightPlan Active="true" Departure="YPAD" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT SEDAN Y465 RACHL/M078F370 Y465 ENLIP ENLI2A/19L</FlightPlan>
+              <FlightPlan Active="true" Departure="YPAD" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT UPROT Y465 RACHL/M078F370 Y465 ENLIP ENLI2A/19L</FlightPlan>
               <Route>ENLIP ODUTO ANSOR PULEX SORVA RUTAT PUBIV ISPON OMGUV BETSO</Route>
             </Aircraft>
             <Aircraft Callsign="QLK2522" Type="DH8C" Delay="840" StartAuto="true">
@@ -2268,7 +2265,7 @@
               <Squawk Code="4112" ModeC="true" />
               <Position Latitude="-28.725" Longitude="151.71" Speed="450" Altitude="39000" />
               <Cleared Level="3000" />
-              <FlightPlan Active="true" Departure="YPAD" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT SEDAN Y465 ENLIP ENLI2A/19L</FlightPlan>
+              <FlightPlan Active="true" Departure="YPAD" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT UPROT Y465 ENLIP ENLI2A/19L</FlightPlan>
               <Route>ENLIP ODUTO ANSOR PULEX SORVA RUTAT PUBIV ISPON OMGUV BETSO</Route>
             </Aircraft>
             <Aircraft Callsign="QFA616" Type="B738" Delay="720" StartAuto="true">
@@ -2603,7 +2600,7 @@
           <Squawk Code="3101" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-37.68429299999999" Longitude="144.840701" Speed="1" Altitude="312" />
-          <FlightPlan Active="true" Departure="YMML" Destination="YBLN" Alternative="" Rules="1" CruiseSpeed="454" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2/v/">CRENA1/34 CRENA Q158 COBEL DCT RERON DCT REDEL DCT NOVIN DCT BLN DCT</FlightPlan>
+          <FlightPlan Active="true" Departure="YMML" Destination="YBLN" Alternative="" Rules="1" CruiseSpeed="454" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2/v/">CRENA1/34 CRENA Q158 COBEL DCT HOODY DCT BLN DCT</FlightPlan>
           <Route>MMLSH HOPLA CRENA</Route>
         </Aircraft>
         <Aircraft Callsign="YUP" Type="C182" Delay="240">
@@ -3009,7 +3006,7 @@
           <Squawk Code="4122" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-34.583427" Longitude="149.756614" Speed="435" Altitude="20000" />
-          <FlightPlan Active="true" Departure="YPAD" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="REG/VHJST  PER/D NAV/RNP2 OPR/JETSTAR     /v/">PANKI H247 CULIN Y59 RIVET RIVET3/34L</FlightPlan>
+          <FlightPlan Active="true" Departure="YPAD" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="REG/VHJST  PER/D NAV/RNP2 OPR/JETSTAR     /v/">AVDEN H247 CULIN Y59 RIVET RIVET3/34L</FlightPlan>
           <Route>TARAL RIVET BIGEM TAMMI BOOGI DUDOK NASHO</Route>
         </Aircraft>
         <Aircraft Callsign="QFA509" Type="B738" Delay="0">
@@ -3187,7 +3184,7 @@
           <Squawk Code="4122" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-34.583427" Longitude="149.756614" Speed="435" Altitude="20000" />
-          <FlightPlan Active="true" Departure="YPAD" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="REG/VHJST  PER/D NAV/RNP2 OPR/JETSTAR     /v/">PANKI H247 CULIN Y59 RIVET RIVET3/34L</FlightPlan>
+          <FlightPlan Active="true" Departure="YPAD" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="REG/VHJST  PER/D NAV/RNP2 OPR/JETSTAR     /v/">AVDEN H247 CULIN Y59 RIVET RIVET3/34L</FlightPlan>
           <Route>TARAL RIVET BIGEM TAMMI BOOGI DUDOK NASHO</Route>
         </Aircraft>
         <Aircraft Callsign="QFA509" Type="B738" Delay="0">
@@ -3474,8 +3471,8 @@
       <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVFU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">ABBEY3/16L WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
       <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
-        <TimedMessage Time="240" Message="(Coordination SY ADC > SDS): 'Next, Runway 16L, JST531'" />
-        <TimedMessage Time="300" Message="Takeoff" />
+        <TimedMessage Time="240" Message="SY ADC to SY DEP Coord: 'Next, Runway 16L, JST531'" />
+        <TimedMessage Time="300" Message="Set Level to Coordinated instruction, and Takeoff" />
       </TimedMessages>
     </Aircraft>
 	<Aircraft Callsign="QFA11" Type="A388" Delay="0" StartAuto="false">
@@ -3497,8 +3494,8 @@
       <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDFGHRYZ/LB1" Rules="I" CruiseSpeed="405" ETD="0000" ATD="0000" RFL="260" EETHours="1" EETMins="25" FuelHours="2" FuelMins="30" Remarks="PBN/A1B2C2D2O2 NAV/RNP2 DOF/220501 REG/VHNJI EET/YBBB0002 CODE/7C431C OPR/NATIONAL JET SYSTEMS PER/C /V/">ABBEY3/16L WOL H65 RAZZI Q29 LIZZI DCT</FlightPlan>
       <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
-        <TimedMessage Time="340" Message="(Coordination SY ADC > SDS): 'Next, Runway 16L, JTE7445'" />
-        <TimedMessage Time="400" Message="Takeoff" />
+        <TimedMessage Time="340" Message="SY ADC to SY DEP Coord: 'Next, Runway 16L, JTE7445'" />
+        <TimedMessage Time="400" Message="Set Level to Coordinated instruction, and Takeoff" />
 		<TimedMessage Time="1000" Message="Set Speed to 250kts" />
       </TimedMessages>
     </Aircraft>
@@ -3530,8 +3527,8 @@
       <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
 		    <TimedMessage Time="300" Message="Activate Plan" />
-        <TimedMessage Time="840" Message="(Coordination SY ADC > SDS): 'Next, Runway 16L, VOZ876'" />
-        <TimedMessage Time="900" Message="Takeoff" />
+        <TimedMessage Time="840" Message="SY ADC to SY DEP Coord: 'Next, Runway 16L, VOZ876'" />
+        <TimedMessage Time="900" Message="Set Level to Coordinated instruction, and Takeoff" />
       </TimedMessages>
     </Aircraft>
 	<Aircraft Callsign="AGC331" Type="A320" Delay="0" StartAuto="false">
@@ -3564,8 +3561,8 @@
       <Route>WOL RAZZI TANTA ANLID RUMIE NABBA BULLA LUVAS LIZZI ML</Route>
 	  <TimedMessages>
 		    <TimedMessage Time="500" Message="Activate Plan" />
-        <TimedMessage Time="1040" Message="(Coordination SY ADC > SDS): 'Next, Runway 16L, QFA483'" />
-        <TimedMessage Time="1100" Message="Takeoff" />
+        <TimedMessage Time="1040" Message="SY ADC to SY DEP Coord: 'Next, Runway 16L, QFA483'" />
+        <TimedMessage Time="1100" Message="Set Level to Coordinated instruction, and Takeoff" />
       </TimedMessages>
     </Aircraft>
 	<Aircraft Callsign="JST611" Type="A320" Delay="0" StartAuto="false">
@@ -3972,7 +3969,6 @@
 	- 123.05 only
 - **Traffic**:
 	- RXA4356 needs descent for YPLC
-	- VOZ1385 and JST766 are estimating BLACK at the same time, require sequencing
 	- TGG317 and QFA1969 are estimating BLACK at the same time, require sequencing
 	- Several arrivals via DUKES as well. RXA489 and VOZ223 are on top of each other, will require sequencing 
 	- QFA648 crossing to the North, not yet assessed
@@ -3981,8 +3977,7 @@
 
 	Any Questions?
 	</StudentBriefing>
-	<InstructorNotes>- **VOZ1385** and **JST766** will require sequencing through BLACK
-- **TGG317** and **QFA1969** will require sequencing through BLACK
+	<InstructorNotes>- **TGG317** and **QFA1969** will require sequencing through BLACK
 - **QFA685**, **RXA489**, **VOZ223**, and **JST766** will require sequencing through ALEXI
 - When Student is selecting how to order the sequence, they would benefit from taking note of the level order (ie, make lower aircraft Number 1)
 - **QLK270** will taxi at YPLC 10 minutes in. Will require mutual traffic with **RXA4356**
@@ -4005,13 +4000,6 @@
 	  <FlightPlan Active="true" Departure="YMML" Destination="YPAD" Alternative="" Rules="I" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H345 AD DCT</FlightPlan>
 	  <Route>BORTO DUKES DRINA AD</Route>
 	</Aircraft>
-	<Aircraft Callsign="VOZ239" Type="B738" Delay="0">
-	  <Squawk Code="1146" ModeC="true" />
-	  <Cleared Level="38000" />
-	  <Position Latitude="-36.651782999999995" Longitude="141.530654" Speed="450" Altitude="38000" />
-	  <FlightPlan Active="true" Departure="YMML" Destination="YPAD" Alternative="" Rules="I" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H345 AD DCT</FlightPlan>
-	  <Route>BORTO DUKES DRINA AD</Route>
-	</Aircraft>
 	<Aircraft Callsign="VOZ229" Type="B738" Delay="0">
 	  <Squawk Code="4400" ModeC="true" />
 	  <Cleared Level="38000" />
@@ -4022,7 +4010,7 @@
 	<Aircraft Callsign="VOZ223" Type="B738" Delay="0">
 	  <Squawk Code="4322" ModeC="true" />
 	  <Cleared Level="36000" />
-	  <Position Latitude="-37.04939" Longitude="142.7927" Speed="450" Altitude="36000" />
+	  <Position Latitude="-37.059722" Longitude="142.817222" Speed="450" Altitude="36000" />
 	  <FlightPlan Active="true" Departure="YMML" Destination="YPAD" Alternative="" Rules="I" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H345 AD DCT</FlightPlan>
 	  <Route>BORTO DUKES DRINA AD</Route>
 	</Aircraft>
@@ -4032,13 +4020,9 @@
 	  <Position Latitude="-34.090203" Longitude="142.524659" Speed="450" Altitude="38000" />
 	  <FlightPlan Active="true" Departure="YBBN" Destination="YPAD" Alternative="" Rules="I" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT SANEG Q4 PAVBI Q16 MIA Q4 WOONA Q60 BLACK H309 AD DCT</FlightPlan>
 	  <Route>MIA WOONA BLACK AD</Route>
-	</Aircraft>
-	<Aircraft Callsign="VOZ1385" Type="B738" Delay="0">
-	  <Squawk Code="3265" ModeC="true" />
-	  <Cleared Level="36000" />
-	  <Position Latitude="-34.291621" Longitude="141.774966" Speed="450" Altitude="36000" />
-	  <FlightPlan Active="true" Departure="YBBN" Destination="YPAD" Alternative="" Rules="I" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT SANEG Q4 PAVBI Q16 MIA Q4 WOONA Q60 BLACK H309 AD DCT</FlightPlan>
-	  <Route>WOONA BLACK AD</Route>
+    <TimedMessages>
+      <TimedMessage Time="10" Message="Handoff" />
+    </TimedMessages>
 	</Aircraft>
 	<Aircraft Callsign="RXA4867" Type="SF34" Delay="0" StartAuto="true">
 	  <Squawk Code="3675" ModeC="true" />
@@ -4053,9 +4037,9 @@
 	  <FlightPlan Active="false" Departure="YPLC" Destination="YPAD" Alternative="" Rules="I" CruiseSpeed="220" ETD="0000" ATD="0000" RFL="15000" EETHours="00" EETMins="50" FuelHours="0" FuelMins="0" Remarks="REG/VHSBB NAV/RNP10 /v/">DCT PLC V707 RIKAB N640 AD</FlightPlan>
 	  <Route>TEKOD PILBY RIKAB</Route>
 	  <TimedMessages>
-        <TimedMessage Time="600" Message="Melbourne Centre, IFR DH8C, QLK266, Taxis Runway 19 Port Lincoln for Adelaide" />
-		<TimedMessage Time="850" Message="Select Runway 19, Climb to F125, and Takeoff" />
-      </TimedMessages>
+      <TimedMessage Time="600" Message="Melbourne Centre, IFR DH8C, QLK270, Taxis Runway 19 Port Lincoln for Adelaide" />
+		  <TimedMessage Time="850" Message="Select Runway 19, Climb to F125, and Takeoff" />
+    </TimedMessages>
 	</Aircraft>
 	<Aircraft Callsign="RXA489" Type="B738" Delay="0" StartAuto="false">
       <Squawk Code="3765" ModeC="true" />
@@ -4064,19 +4048,15 @@
       <FlightPlan Departure="YMML" Destination="YPAD" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1L1O1S2 NAV/RNP2 DOF/240101 REG/VHRQP SEL/CEDQ CODE/7C585F OPR/RXA ORGN/KAUSFFLX PER/C /V/">DCT NEVIS H345 DRINA DCT</FlightPlan>
       <Route>BORTO DUKES DRINA AD</Route>
     </Aircraft>
-	<Aircraft Callsign="JST766" Type="A320" Delay="0" StartAuto="false">
-	  <Squawk Code="1714" ModeC="true" />
-	  <Cleared Level="34000" Approach="false" />
-	  <Position Latitude="-34.684722" Longitude="141.796667" Speed="450" Altitude="34000" />
-	  <FlightPlan Departure="YSSY" Destination="YPAD" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVFX OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DCT KADOM H44 MAXEM Q60 BLACK DCT</FlightPlan>
-	  <Route>WOONA BLACK AD</Route>
-	</Aircraft>
 	<Aircraft Callsign="QFA1969" Type="E190" Delay="0" StartAuto="false">
       <Squawk Code="5412" ModeC="true" />
       <Cleared Level="36000" Approach="false" />
       <Position Latitude="-34.636667" Longitude="142.554722" Speed="430" Altitude="36000" />
       <FlightPlan Departure="YWLM" Destination="YPAD" Alternative="" Active="true" Equipment="SDGHIRWYZ/LB1" Rules="I" CruiseSpeed="430" ETD="0000" ATD="0000" RFL="360" EETHours="01" EETMins="30" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/230117 REG/VHUZK EET/YBBB0108 SEL/EQHK CODE/7C68CE OPR/ALLIANCE ORGN/YSSYQFAO PER/C /V/ ">DCT LIMLO H536 OMLAV Q15 WOL J42 CB W148 WG Q60 BLACK DCT</FlightPlan>
       <Route>WOONA BLACK AD</Route>
+      <TimedMessages>
+        <TimedMessage Time="10" Message="Handoff" />
+      </TimedMessages>
     </Aircraft>
 	<Aircraft Callsign="JST499" Type="A21N" Delay="0">
 	  <Squawk Code="6223" ModeC="true" />
@@ -4085,8 +4065,8 @@
 	  <FlightPlan Active="true" Departure="YBCG" Destination="YPAD" Alternative="" Rules="I" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT APAGI Q16 MIA Q4 WOONA Q60 BLACK DCT</FlightPlan>
 	  <Route>VENEL MIA WOONA BLACK AD</Route>
 	  <TimedMessages>
-        <TimedMessage Time="1120" Message="Handoff" />
-      </TimedMessages>
+      <TimedMessage Time="1120" Message="Handoff" />
+    </TimedMessages>
 	</Aircraft>
 	<Aircraft Callsign="FD512" Type="PC12" Delay="0">
 	  <Squawk Code="2000" ModeC="true" />
@@ -4094,9 +4074,9 @@
 	  <FlightPlan Active="false" Departure="YWHA" Destination="YPAD" Alternative="" Rules="I" CruiseSpeed="260" ETD="0000" ATD="0000" RFL="150" EETHours="00" EETMins="50" FuelHours="0" FuelMins="0" Remarks="STS/HOSP PBN/O2S1 NAV/RNP2 DOF/240101 REG/VHFXZ OPR/RFDS PER/C /V/">DCT WHA H84 AD DCT </FlightPlan>
 	  <Route>SEDRA ASILI MARGO AD</Route>
 	  <TimedMessages>
-        <TimedMessage Time="1300" Message="Melbourne Centre, IFR PC12, FD512, Taxis Runway 19 Whyalla for Adelaide" />
-		<TimedMessage Time="1500" Message="Select Runway 17, Climb to F125, and Takeoff" />
-      </TimedMessages>
+      <TimedMessage Time="1300" Message="Melbourne Centre, IFR PC12, FD512, Taxis Runway 17 Whyalla for Adelaide" />
+		  <TimedMessage Time="1500" Message="Select Runway 17, Climb to F125, and Takeoff" />
+    </TimedMessages>
 	</Aircraft>
 // YPAD Departures
 	<Aircraft Callsign="RXA4356" Type="SF34" Delay="0">
@@ -4110,85 +4090,85 @@
 	  <Squawk Code="4402" ModeC="true" />
 	  <Cleared Level="24000" />
 	  <Position Latitude="-34.958056" Longitude="138.517778" Speed="1" Altitude="36" />
-	  <FlightPlan Active="true" Departure="YPAD" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO2/05 BENDO Y12 ARBEY H119 ML DCT</FlightPlan>
+	  <FlightPlan Active="true" Departure="YPAD" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO3/05 BENDO Y12 ARBEY H119 ML DCT</FlightPlan>
 	  <Route>BENDO RELEP LULTO APPLE ARBEY ML</Route>
 	</Aircraft>
 	<Aircraft Callsign="JST765" Type="A321" Delay="0" StartAuto="false">
 	  <Squawk Code="1655" ModeC="true" />
 	  <Cleared Level="24000" Approach="false" />
 	  <Position Latitude="-34.958056" Longitude="138.517778" Speed="0" Altitude="33" />
-	  <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="370" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVWU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">PANKI3/05 PANKI H247 CULIN Y59 RIVET DCT</FlightPlan>
-	  <Route>PANKI BOLAM NATYA TOBOB CULIN TARAL RIVET TESAT</Route>
+	  <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="370" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVWU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">AVDEN1/05 AVDEN H247 CULIN Y59 RIVET DCT</FlightPlan>
+	  <Route>AVDEN BOLAM NATYA TOBOB CULIN TARAL RIVET TESAT</Route>
 	  <TimedMessages>
-        <TimedMessage Time="180" Message="Takeoff" />
-		<TimedMessage Time="900" Message="Set Vertical Speed to 1000ft/min" />
-      </TimedMessages>
+      <TimedMessage Time="180" Message="Takeoff" />
+		  <TimedMessage Time="900" Message="Set Vertical Speed to 1000ft/min" />
+    </TimedMessages>
 	</Aircraft>
 	<Aircraft Callsign="UTY3136" Type="E190" Delay="0" StartAuto="false">
       <Squawk Code="1141" ModeC="true" />
       <Cleared Level="24000" Approach="false" />
       <Position Latitude="-34.958056" Longitude="138.517778" Speed="0" Altitude="33" />
-      <FlightPlan Departure="YPAD" Destination="YOLD" Alternative="" Active="true" Equipment="SDGHIRWYZ/LB1" Rules="I" CruiseSpeed="430" ETD="0000" ATD="0000" RFL="320" EETHours="00" EETMins="45" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/230117 REG/VHUZK EET/YBBB0108 SEL/EQHK CODE/7C68CE OPR/ALLIANCE ORGN/YSSYQFAO PER/C /V/ ">HAWKY5/05 HAWKY J58 WHA W566 YOLD</FlightPlan>
-      <Route>WHAWKY SPOTA WHA POLUP YOLD</Route>
+      <FlightPlan Departure="YPAD" Destination="YOLD" Alternative="" Active="true" Equipment="SDGHIRWYZ/LB1" Rules="I" CruiseSpeed="430" ETD="0000" ATD="0000" RFL="320" EETHours="00" EETMins="45" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/230117 REG/VHUZK EET/YBBB0108 SEL/EQHK CODE/7C68CE OPR/ALLIANCE ORGN/YSSYQFAO PER/C /V/ ">AREPA1/05 AREPA J58 WHA W566 YOLD</FlightPlan>
+      <Route>WAREPA SPOTA WHA POLUP YOLD</Route>
 	  <TimedMessages>
-        <TimedMessage Time="330" Message="Takeoff" />
-		<TimedMessage Time="650" Message="Set Vertical Speed to 1000ft/min" />
-		<TimedMessage Time="1600" Message="'UTY3136, Request DCT OMKEK for the RNP Runway 25'" />
-      </TimedMessages>
+      <TimedMessage Time="330" Message="Takeoff" />
+		  <TimedMessage Time="650" Message="Set Vertical Speed to 1000ft/min" />
+		  <TimedMessage Time="1600" Message="'UTY3136, Request DCT OMKEK for the RNP Runway 25'" />
+    </TimedMessages>
     </Aircraft>
 	<Aircraft Callsign="VOZ212" Type="B738" Delay="0">
 	  <Squawk Code="4165" ModeC="true" />
 	  <Cleared Level="24000" />
 	  <Position Latitude="-34.958056" Longitude="138.517778" Speed="0" Altitude="33" />
-	  <FlightPlan Active="true" Departure="YPAD" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="PBN/A1B2C2D2O2S2T1 NAV/RNP2  REG/VHYIV SEL/KMLR CODE/7C7AB5 OPR/VIRGIN AUSTRALIA PER/C RMK/CALLSIGN VELOCITY  /v/">BENDO2/05 BENDO Y12 ARBEY</FlightPlan>
+	  <FlightPlan Active="true" Departure="YPAD" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="PBN/A1B2C2D2O2S2T1 NAV/RNP2  REG/VHYIV SEL/KMLR CODE/7C7AB5 OPR/VIRGIN AUSTRALIA PER/C RMK/CALLSIGN VELOCITY  /v/">BENDO3/05 BENDO Y12 ARBEY</FlightPlan>
 	  <Route>BENDO RELEP LULTO APPLE ARBEY</Route>
 	  <TimedMessages>
-        <TimedMessage Time="1000" Message="Takeoff" />
-      </TimedMessages>
+      <TimedMessage Time="1000" Message="Takeoff" />
+    </TimedMessages>
 	</Aircraft>
 	<Aircraft Callsign="QFA7354" Type="B462" Delay="0" StartAuto="false">
       <Squawk Code="5547" ModeC="true" />
       <Cleared Level="24000" Approach="false" />
       <Position Latitude="-34.958056" Longitude="138.517778" Speed="0" Altitude="33" />
-      <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="false" Equipment="SDFGHRY/LB1" Rules="I" CruiseSpeed="398" ETD="0000" ATD="0000" RFL="290" EETHours="1" EETMins="35" FuelHours="2" FuelMins="20" Remarks="PBN/B2C2D2O2 DOF/240101 REG/VHSAZ CODE/7C5B39 OPR/EXP FREIGHT AUST ORGN/YSSYQFAO /V/">PANKI3/05 PANKI H247 CULIN Y59 RIVET DCT</FlightPlan>
-      <Route>PANKI BOLAM NATYA TOBOB CULIN TARAL RIVET TESAT</Route>
+      <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="false" Equipment="SDFGHRY/LB1" Rules="I" CruiseSpeed="398" ETD="0000" ATD="0000" RFL="290" EETHours="1" EETMins="35" FuelHours="2" FuelMins="20" Remarks="PBN/B2C2D2O2 DOF/240101 REG/VHSAZ CODE/7C5B39 OPR/EXP FREIGHT AUST ORGN/YSSYQFAO /V/">AVDEN1/05 AVDEN H247 CULIN Y59 RIVET DCT</FlightPlan>
+      <Route>AVDEN BOLAM NATYA TOBOB CULIN TARAL RIVET TESAT</Route>
 	  <TimedMessages>
 		<TimedMessage Time="1000" Message="Activate Plan" />
-        <TimedMessage Time="1600" Message="Takeoff" />
-      </TimedMessages>
+      <TimedMessage Time="1600" Message="Takeoff" />
+    </TimedMessages>
 	</Aircraft>
 	<Aircraft Callsign="QFA746" Type="B738" Delay="0" StartAuto="false">
       <Squawk Code="1145" ModeC="true" />
       <Cleared Level="24000" Approach="false" />
       <Position Latitude="-34.958056" Longitude="138.517778" Speed="0" Altitude="33" />
-      <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="390" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/ ">PANKI3/05 PANKI H247 CULIN Y59 RIVET DCT</FlightPlan>
-      <Route>PANKI BOLAM NATYA TOBOB CULIN TARAL RIVET TESAT</Route>
+      <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="390" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/ ">AVDEN1/05 AVDEN H247 CULIN Y59 RIVET DCT</FlightPlan>
+      <Route>AVDEN BOLAM NATYA TOBOB CULIN TARAL RIVET TESAT</Route>
 	  <TimedMessages>
-        <TimedMessage Time="1100" Message="Activate Plan" />
-        <TimedMessage Time="1700" Message="Takeoff" />
-      </TimedMessages>
+      <TimedMessage Time="1100" Message="Activate Plan" />
+      <TimedMessage Time="1700" Message="Takeoff" />
+    </TimedMessages>
     </Aircraft>
 // Other
 	<Aircraft Callsign="SIA7297" Type="B744" Delay="0">
-	  <Squawk Code="4420" ModeC="true" />
-	  <Cleared Level="36000" />
+	  <Squawk Code="4426" ModeC="true" />
+	  <Cleared Level="36000" Approach="false" />
 	  <Position Latitude="-37.155278" Longitude="144.326111" Speed="350" Altitude="16000" />
 	  <FlightPlan Active="true" Departure="YMML" Destination="WSSS" Alternative="" Equipment="SDE1E2E3FGHIJ3J5M1RWXYZ/LB1D1" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="36000" EETHours="08" EETMins="20" FuelHours="9" FuelMins="50" Remarks="PBN/A1B1C1D1L1O1S2 NAV/RNP2 DAT/CPDLCX 1FANS DOF/240101 REG/9VSFO EET/YBBB0246 WAAF0448 WIIF0613 WSJC0651 RALT/YPAD YPPH WADD SEL/AJBE CODE/76CCCF OPR/SIA PER/D RMK/CARGO FLIGHT ACASII EQUIPPED TCAS /V/">DCT KEPPA Q168 KABEK DCT QUORN DCT VIRUV DCT ARENI DCT AYE DCT SCHEE DCT LIBTU T29 CIN A576 ATMAP M635 BLI M635 SURGA T23 UGEBO</FlightPlan>
 	  <Route>KEPPA OPORI BOLAM KABEK QUORN VIRUV ARENI AYE</Route>
 	  <TimedMessages>
-        <TimedMessage Time="1" Message="Climb now to F360 (Level Change mode)" />
-        <TimedMessage Time="1120" Message="Handoff" />
-      </TimedMessages>
+      <TimedMessage Time="1" Message="Climb now to F360 (Level Change mode)" />
+      <TimedMessage Time="1120" Message="Handoff" />
+    </TimedMessages>
 	</Aircraft>
 	<Aircraft Callsign="QFA648" Type="A332" Delay="0">
 	  <Squawk Code="2344" ModeC="true" />
 	  <Cleared Level="31000" />
 	  <Position Latitude="-32.882222" Longitude="132.742222" Speed="465" Altitude="31000" />
-	  <FlightPlan Active="true" Departure="YPPH" Destination="YSSY" Alternative="" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="34000" EETHours="08" EETMins="20" FuelHours="9" FuelMins="50" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 RNVD1A1 SUR/260B DOF/240101 REG/VHEBO EET/YBBB0103 SEL/CEFS CODE/7C5325 OPR/QFA ORGN/YSSYQFAO PER/C /V/">DCT PH H18 MUBID J21 BORLI UH205 CULIN Y59 RIVET DCT</FlightPlan>
+	  <FlightPlan Active="true" Departure="YPPH" Destination="YSSY" Alternative="" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="31000" EETHours="08" EETMins="20" FuelHours="9" FuelMins="50" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 RNVD1A1 SUR/260B DOF/240101 REG/VHEBO EET/YBBB0103 SEL/CEFS CODE/7C5325 OPR/QFA ORGN/YSSYQFAO PER/C /V/">DCT PH H18 MUBID J21 BORLI UH205 CULIN Y59 RIVET DCT</FlightPlan>
 	  <Route>ABTOD WHA KABEK IBABI UVUPU BORLI CULIN TARAL RIVET TESAT</Route>
 	  <TimedMessages>
-        <TimedMessage Time="2300" Message="'QFA648, Request F390'" />
-      </TimedMessages>
+      <TimedMessage Time="2220" Message="'QFA648, Request F390'" />
+    </TimedMessages>
 	</Aircraft>
 	<Aircraft Callsign="XLQ" Type="RV7" Delay="0">
 	  <Squawk Code="1200" ModeC="true" />
@@ -4196,8 +4176,8 @@
 	  <FlightPlan Active="false" Departure="YNRC" Destination="YADG" Alternative="" Rules="V" CruiseSpeed="110" ETD="0000" ATD="0000" RFL="6500" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="REG/VHXLQ       /v/">YSCK YGWA</FlightPlan>
 	  <Route>YSCK YGWA YADG</Route>
 	  <TimedMessages>
-        <TimedMessage Time="900" Message="Melbourne Centre, VFR RV7, XLQ, 30nm South West of Bordertown, A065, Request Flight Following for YADG" />
-      </TimedMessages>
+      <TimedMessage Time="900" Message="Melbourne Centre, VFR RV7, XLQ, 30nm South West of Bordertown, A065, Request Flight Following for YADG" />
+    </TimedMessages>
 	</Aircraft>
 	</Targets>
 </ScenarioFile>
@@ -4250,9 +4230,9 @@
           <Aircraft Callsign="ANO182" Type="E170" Delay="0">
             <Squawk Code="6764" ModeC="true" />
             <Cleared Level="18000" />
-            <Position Latitude="-12.483316000000002" Longitude="131.177268" Speed="250" Altitude="9500" />
+            <Position Latitude="-12.233056" Longitude="130.865278" Speed="250" Altitude="9500" />
             <FlightPlan Active="true" Departure="YPDN" Destination="YBTL" Alternative="" Rules="I" CruiseSpeed="330" ETD="0000" ATD="0000" RFL="35000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">RUPEG1/29 RUPEG DCT IGUVI J138 ONARA DCT KALBA DCT SEMBU DCT TL DCT </FlightPlan>
-            <Route>RUPEG IGUVI</Route>
+            <Route>BAXIB SNICK RUPEG IGUVI SURVO NTN ONARA KALBA SEMBU TL</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ9901" Type="B738" Delay="0">
             <Squawk Code="1433" ModeC="true" />
@@ -4414,7 +4394,7 @@
             <Route>JULUP WANGI DN</Route>
             <TimedMessages>
             <TimedMessage Time="15" Message="'Brisbane Centre, IFR Conquest, JFO, Taxiing Runway 12 Kununurra for Darwin'" />
-            <TimedMessage Time="200" Message="Takeoff and Climb to F125" />
+            <TimedMessage Time="200" Message="Select Runway 12, Climb to F125, and Takeoff" />
           </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="HVH" Type="SW4" Delay="0">
@@ -4424,7 +4404,7 @@
           <Route>JULUP WANGI DN</Route>
           <TimedMessages>
             <TimedMessage Time="60" Message="HVH, Metroliner, IFR, Taxiing Port Keats for Darwin, Runway 34" />
-            <TimedMessage Time="240" Message="Takeoff and Climb to F125" />
+            <TimedMessage Time="240" Message="Select Runway 34, Climb to F125, and Takeoff" />
           </TimedMessages>
           </Aircraft>
         </Targets>
@@ -4484,7 +4464,7 @@
               <Route>LOVGO MOVBU PKS BORLI</Route>
               <TimedMessages>
                 <TimedMessage Time="2520" Message="STT, IFR C182, Taxis Tamworth for Garrath, Runway 30R." />
-                <TimedMessage Time="2580" Message="STT Takeoff." />
+                <TimedMessage Time="2580" Message="Select Runway 30R, Climb to F125, and Takeoff" />
               </TimedMessages> 
           </Aircraft>
           <Aircraft Callsign="QLK202D" Type="DH8D" Delay="0">
@@ -4502,7 +4482,7 @@
               <Route>IVL CFS</Route>
               <TimedMessages>
               <TimedMessage Time="5" Message="MWE, IFR Baron, Taxis Moree for Port Macquarie, Runway 01." />
-              <TimedMessage Time="240" Message="MWE Takeoff." />
+              <TimedMessage Time="240" Message="Select Runway 01, Climb to A085, and Takeofff." />
             </TimedMessages> 
           </Aircraft>
           <Aircraft Callsign="REI" Type="C182" Delay="0">
@@ -4528,9 +4508,9 @@
               <FlightPlan Departure="YPMQ" Destination="YMOR" Alternative="" Active="false" Rules="I" CruiseSpeed="290" ETD="0000" ATD="0000" RFL="18000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">DCT PMQ W381 ARM W674 IVL MOR DCT</FlightPlan>
               <Route>ARM IVL MOR</Route>
               <TimedMessages>
-                <TimedMessage Time="720" Message="AM223, IFR King Air, Taxis Port Macquarie for MOree, Runway 03." />
-                <TimedMessage Time="960" Message="MWE Takeoff." />
-                <TimedMessage Time="1920" Message="Request DCT MRZSE Moree Sierra Echo for the RNP Runway 01." />
+                <TimedMessage Time="720" Message="AM223, IFR King Air, Taxis Port Macquarie for Moree, Runway 03." />
+                <TimedMessage Time="960" Message="Select Runway 03, Climb to A085, and Takeoff" />
+                <TimedMessage Time="1920" Message="Request DCT MRZSE for the RNP Runway 01." />
               </TimedMessages> 
           </Aircraft>
           <Aircraft Callsign="EWI" Type="BE58" Delay="0">
@@ -4610,7 +4590,7 @@
               <Squawk Code="4036" ModeC="true" />
               <Cleared Level="35000" />
               <Position Latitude="-33.417778" Longitude="142.781945" Speed="450" Altitude="35000" />
-              <FlightPlan Departure="YPAD" Destination="YBBN" Alternative="" Active="true" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">DCT SEDAN Y27 IGIPA Y46 EMTID Y27 ENLIP DCT</FlightPlan>
+              <FlightPlan Departure="YPAD" Destination="YBBN" Alternative="" Active="true" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">DCT UPROT Y27 IGIPA Y46 EMTID Y27 ENLIP DCT</FlightPlan>
               <Route>ALASU GUMAP AVGEK RACHL EMTID SUKTU</Route>
           </Aircraft>
           <Aircraft Callsign="SIA241" Type="B773" Delay="0">
@@ -4666,36 +4646,36 @@
           <Squawk Code="2422" ModeC="true" />
           <Cleared Level="15000" />
           <Position Latitude="-34.940449" Longitude="138.542794" Speed="1" Altitude="36" />
-          <FlightPlan Departure="YPAD" Destination="YMIA" Alternative="" Active="true" Rules="I" CruiseSpeed="270" ETD="0000" ATD="0000" RFL="15000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/GPSRNAV PER/B /v/">YPAD/23 SEDAN V361 MIA DCT</FlightPlan>
-          <Route>SEDAN SILVN MIA</Route>
+          <FlightPlan Departure="YPAD" Destination="YMIA" Alternative="" Active="true" Rules="I" CruiseSpeed="270" ETD="0000" ATD="0000" RFL="15000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/GPSRNAV PER/B /v/">YPAD/23 UPROT V361 MIA DCT</FlightPlan>
+          <Route>UPROT SILVN MIA</Route>
         </Aircraft>
         <Aircraft Callsign="QFA525" Type="B738" Delay="360" StartAuto="true">
           <Squawk Code="2251" ModeC="true" />
           <Cleared Level="24000" />
           <Position Latitude="-34.940449" Longitude="138.542794" Speed="1" Altitude="36" />
-          <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YPAD" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="33000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/RNP2 REG/VHVXY PER/C /v/">BENDO2/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
+          <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YPAD" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="33000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/RNP2 REG/VHVXY PER/C /v/">BENDO3/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
           <Route>COLPY SULLY MORPH CLARY BARKA MURRY BENDO RELEP LULTO APPLE ARBEY</Route>
         </Aircraft>
         <Aircraft Callsign="QFA527" Type="B738" Delay="780" StartAuto="true">
           <Squawk Code="2257" ModeC="true" />
           <Cleared Level="24000" />
           <Position Latitude="-34.940449" Longitude="138.542794" Speed="1" Altitude="36" />
-          <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YPAD" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="33000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/RNP2 REG/VHVXX PER/C /v/">BENDO2/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
+          <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YPAD" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="33000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/RNP2 REG/VHVXX PER/C /v/">BENDO3/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
           <Route>COLPY SULLY MORPH CLARY BARKA MURRY BENDO RELEP LULTO APPLE ARBEY</Route>
         </Aircraft>
         <Aircraft Callsign="QFA723" Type="B738" Delay="120" StartAuto="true">
           <Squawk Code="4123" ModeC="true" />
           <Cleared Level="24000" />
           <Position Latitude="-34.940456" Longitude="138.542781" Speed="1" Altitude="36" />
-          <FlightPlan Departure="YPAD" Destination="YBAS" Alternative="YAYE" Active="true" Rules="I" CruiseSpeed="435" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/GPSRNAV PER/C /v/">HAWKY5/23 HAWKY J58 WHA J251 AS</FlightPlan>
-          <Route>CORNS KEEFO BIGAL HAWKY SPOTA WHA OJJAY WR CARTS GOMUL SARAH SADEL AS</Route>
+          <FlightPlan Departure="YPAD" Destination="YBAS" Alternative="YAYE" Active="true" Rules="I" CruiseSpeed="435" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/GPSRNAV PER/C /v/">AREPA1/23 AREPA J58 WHA J251 AS</FlightPlan>
+          <Route>CORNS KEEFO BIGAL AREPA SPOTA WHA OJJAY WR CARTS GOMUL SARAH SADEL AS</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ455" Type="B738" Delay="1380" StartAuto="true">
           <Squawk Code="2421" ModeC="true" />
           <Cleared Level="24000" />
           <Position Latitude="-34.940438" Longitude="138.542781" Speed="1" Altitude="36" />
-          <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/GPSRNAV PER/C /v/">PANKI3/23 PANKI H247 CULIN Y59 TESAT</FlightPlan>
-          <Route>COLPY SULLY MORPH CLARY BARKA MURRY PANKI BOLAM NATYA TOBOB CULIN TARAL RIVET</Route>
+          <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/GPSRNAV PER/C /v/">AVDEN1/23 AVDEN H247 CULIN Y59 TESAT</FlightPlan>
+          <Route>COLPY SULLY MORPH CLARY BARKA MURRY AVDEN BOLAM NATYA TOBOB CULIN TARAL RIVET</Route>
         </Aircraft>
         <Aircraft Callsign="MHB" Type="PC12" Delay="600" StartAuto="true">
           <Squawk Code="2574" ModeC="true" />
@@ -4711,7 +4691,7 @@
           <Route>WHA</Route>
           <TimedMessages>
             <TimedMessage Time="1140" Message="YTU, IFR Cessna 172, Taxis Port Lincoln for Port Augusta, Runway 19" />
-            <TimedMessage Time="1340" Message="Takeoff" />
+            <TimedMessage Time="1340" Message="Select Runway 19, Climb to F125, and Takeoff" />
           </TimedMessages>
         </Aircraft>
         <Aircraft Callsign="HOT" Type="C182" Delay="0">
@@ -4728,7 +4708,7 @@
           <Route>VAVPA WOKKA TYNDI WENDY</Route>
           <TimedMessages>
             <TimedMessage Time="660" Message="FD511, IFR PC12, Taxis Kingscote to Melbourne, Runway 19" />
-            <TimedMessage Time="840" Message="Takeoff" />
+            <TimedMessage Time="840" Message="Select Runway 19, Climb to F125, and Takeoff" />
           </TimedMessages>
         </Aircraft>
         <Aircraft Callsign="QFA650" Type="A332" Delay="0">
@@ -4736,7 +4716,7 @@
           <Cleared Level="37000" />
           <Position Latitude="-34.59" Longitude="132.62" Speed="440" Altitude="37000" />
           <FlightPlan Departure="YPPH" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="37000" EETHours="02" EETMins="30" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 PER/D/v/">HECTO Y135 TEDUS J15 AD H247 CULIN Y59 RIVET</FlightPlan>
-          <Route>TUTNO ROGAS AD PANKI BOLAM</Route>
+          <Route>TUTNO DADRU AD AVDEN BOLAM</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ1782" Type="B738" Delay="0">
           <Squawk Code="4045" ModeC="true" />
@@ -4802,13 +4782,13 @@
         
         STARS are the same for both 03/06. Student will need to sequence aircraft in queue for each runway.
         
-        UAE420 from the west will need coordination. You will be prompted for this.</InstructorNotes>
+        If UAE420 is not correlating properly, set departure time to 9 hours in the past.</InstructorNotes>
         <Targets>
           <Aircraft Callsign="NWK1843" Type="F100" Delay="0">
             <Squawk Code="1002" ModeC="true" />
             <Cleared Level="32000" />
             <Position Latitude="-27.17" Longitude="117.33000000000001" Speed="450" Altitude="32000" />
-            <FlightPlan Departure="YPBO" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PBO Q7 RULVI Q9 AVPAL Q38 JULIM DCT</FlightPlan>
+            <FlightPlan Departure="YPBO" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="428" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PBO Q7 ISDOR Q9 AVPAL Q38 JULIM DCT</FlightPlan>
             <Route>AVPAL HINDS CALIG JULIM</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ9212" Type="F100" Delay="0">
@@ -4836,29 +4816,29 @@
             <Squawk Code="1006" ModeC="true" />
             <Cleared Level="36000" />
             <Position Latitude="-33.120000000000005" Longitude="120.02000000000002" Speed="450" Altitude="36000" />
-            <FlightPlan Departure="YSSY" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="472" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT KADOM H44 AD Q33 ESP Q158 BEVLY DCT</FlightPlan>
-            <Route>HAMTN BEVLY</Route>
+            <FlightPlan Departure="YSSY" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="472" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT KADOM H44 AD Q33 ESP Q158 KABLI DCT</FlightPlan>
+            <Route>MALUP KABLI</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ679" Type="B738" Delay="0">
             <Squawk Code="1007" ModeC="true" />
             <Cleared Level="38000" />
             <Position Latitude="-33.67" Longitude="121.81" Speed="450" Altitude="38000" />
-            <FlightPlan Departure="YMML" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="448" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CRENA Q158 BEVLY DCT</FlightPlan>
-            <Route>ESMIN HAMTN BEVLY</Route>
+            <FlightPlan Departure="YMML" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="448" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CRENA Q158 KABLI DCT</FlightPlan>
+            <Route>ESMIN MALUP KABLI</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ681" Type="B738" Delay="0">
             <Squawk Code="1010" ModeC="true" />
             <Cleared Level="34000" />
             <Position Latitude="-34.31" Longitude="124.26" Speed="450" Altitude="34000" />
-            <FlightPlan Departure="YMML" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="34000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CRENA Q158 BEVLY DCT</FlightPlan>
-            <Route>ESP HAMTN BEVLY</Route>
+            <FlightPlan Departure="YMML" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="34000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CRENA Q158 KABLI DCT</FlightPlan>
+            <Route>ESP MALUP KABLI</Route>
           </Aircraft>
           <Aircraft Callsign="QFA647" Type="B738" Delay="0">
             <Squawk Code="3210" ModeC="true" />
             <Cleared Level="36000" />
             <Position Latitude="-34.36" Longitude="124.32" Speed="450" Altitude="36000" />
-            <FlightPlan Departure="YMML" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CRENA Q158 BEVLY DCT</FlightPlan>
-            <Route>ESP HAMTN BEVLY</Route>
+            <FlightPlan Departure="YMML" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CRENA Q158 KABLI DCT</FlightPlan>
+            <Route>ESP MALUP KABLI</Route>
           </Aircraft>
           <Aircraft Callsign="ROK" Type="BE20" Delay="0">
             <Squawk Code="1011" ModeC="true" />
@@ -4872,28 +4852,28 @@
             <Cleared Level="18000" />
             <Position Latitude="-31.957319" Longitude="115.96009399999998" Speed="1" Altitude="69" />
             <FlightPlan Departure="YPPH" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="453" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">MUBID3/03 MUBID J21 ABTOD/M081F410 J21 BORLI UH205 CULIN Y59 RIVET DCT</FlightPlan>
-            <Route>MIDLA ALWYN AMANA MECKI BIRER MUBID OLRUX IVPEM</Route>
+            <Route>MUBID OLRUX IVPEM</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ684" Type="B738" Delay="2220" StartAuto="true">
             <Squawk Code="2002" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-31.957319" Longitude="115.96009399999998" Speed="1" Altitude="69" />
             <FlightPlan Departure="YPPH" Destination="YMML" Alternative="" Active="true" Rules="I" CruiseSpeed="453" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">MEMUP4/03 MEMUP Y53 RERON/N0447F390 Y53 WENDY DCT</FlightPlan>
-            <Route>MIDLA ALWYN AMANA MECKI BIRER MEMUP RERON RIDLE</Route>
+            <Route>MEMUP RERON RIDLE</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ9397" Type="F100" Delay="0">
             <Squawk Code="2003" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-31.957319" Longitude="115.96009399999998" Speed="1" Altitude="69" />
             <FlightPlan Departure="YPPH" Destination="YGRM" Alternative="" Active="true" Rules="I" CruiseSpeed="453" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">AMANA4/03 AMANA Y31 LAKIR Y69 LEO DCT</FlightPlan>
-            <Route>MIDLA ALWYN AMANA LAKIR BOSLI YOKRA LEO</Route>
+            <Route>AMANA LAKIR BOSLI YOKRA LEO</Route>
           </Aircraft>
           <Aircraft Callsign="AEP" Type="DH8A" Delay="420" StartAuto="true">
             <Squawk Code="2004" ModeC="true" />
             <Cleared Level="16000" />
             <Position Latitude="-31.957319" Longitude="115.96009399999998" Speed="0" Altitude="69" />
             <FlightPlan Departure="YPPH" Destination="YGEL" Alternative="" Active="true" Rules="I" CruiseSpeed="245" ETD="0000" ATD="0000" RFL="16000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">OTLED5/03 OTLED Q17 ONGAR W14 GEL DCT</FlightPlan>
-            <Route>MIDLA ANCOR ENSUR LIDGI ORATI OSADA POSAS IRNOD LEVKA OTLED ONGAR GEL</Route>
+            <Route>OTLED ONGAR GEL</Route>
           </Aircraft>
           <Aircraft Callsign="QFA776" Type="B738" Delay="0">
             <Squawk Code="2005" ModeC="true" />
@@ -4912,11 +4892,11 @@
           <Aircraft Callsign="JST901" Type="A320" Delay="0">
             <Squawk Code="2000" ModeC="false" />
             <Position Latitude="-33.693901" Longitude="115.39834900000001" Speed="0" Altitude="56" />
-            <FlightPlan Departure="YBLN" Destination="YMML" Alternative="" Active="false" Rules="I" CruiseSpeed="453" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT BLN DCT PAVSO DCT REDEL DCT RERON Y53 WENDY</FlightPlan>
-            <Route>PAVSO REDEL RERON</Route>
+            <FlightPlan Departure="YBLN" Destination="YMML" Alternative="" Active="false" Rules="I" CruiseSpeed="453" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT BLN DCT PAVSO DCT NIPON DCT VIMUS Y53 WENDY DCT </FlightPlan>
+            <Route>PAVSO NIPON VIMUS</Route>
             <TimedMessages>
               <TimedMessage Time="1560" Message="JST901, IFR A320, Taxis Busselton for Melbourne, Runway 03" />
-              <TimedMessage Time="1920" Message="Takeoff" />
+              <TimedMessage Time="1920" Message="Select Runway 03, Climb to F125, and Takeoff" />
             </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="NTE" Type="BE20" Delay="1800" StartAuto="true">
@@ -4941,7 +4921,7 @@
             <Route>HOODY</Route>
             <TimedMessages>
               <TimedMessage Time="60" Message="FD672, IFR PC12, Taxis Albany for Esperence, Runway 14." />
-              <TimedMessage Time="480" Message="Takeoff." />
+              <TimedMessage Time="480" Message="Select Runway 14, Climb to F125, and Takeoff" />
             </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="PIG" Type="C210" Delay="0">
@@ -4952,43 +4932,43 @@
             <Route>BLN YBLN</Route>
             <TimedMessages>
               <TimedMessage Time="60" Message="PIG, IFR Cessna 210, Taxis Albany for Busselton, Runway 14." />
-              <TimedMessage Time="180" Message="Takeoff." />
+              <TimedMessage Time="180" Message="Select Runway 14, Climb to F125, and Takeoff" />
             </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="UAE420" Type="A388" Delay="0">
             <Squawk Code="2000" ModeC="true" />
             <Cleared Level="41000" />
-            <Position Latitude="-27.33" Longitude="108.46599999999998" Speed="450" Altitude="41000" />
-            <FlightPlan Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="481" ETD="0000" ATD="0000" RFL="41000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT NINOB MERIB T12 IPMOR DCT</FlightPlan>
+            <Position Latitude="-27.33" Longitude="108.466" Speed="450" Altitude="41000" />
+            <FlightPlan Departure="OMDB" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="481" ETD="0000" ATD="0000" RFL="41000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT KITAL L894 MERIB T12 IPMOR DCT</FlightPlan>
             <Route>MERIB OPEGA KAGMI</Route>
           </Aircraft>
           <Aircraft Callsign="QTR901" Type="A388" Delay="1860" StartAuto="true">
             <Squawk Code="6456" ModeC="true" />
             <Cleared Level="18000" />
-            <Position Latitude="-31.957319" Longitude="115.96009399999998" Speed="1" Altitude="69" />
-            <FlightPlan Departure="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="484" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">OPEGA5/03 OPEGA DCT BONGS/N0498F360 DCT 20S105E 13S100E 07S095E 06S094E/N0490F380 04S092E DCT ELATI N640 CL/N0484F400 N640 KAT P570 BASUR/M084F400 P570 KITAL/N0481F380 P570 EMURU N563 UMIBU P899 MEKRI/N0470F320 P899 MEKMA </FlightPlan>
-            <Route>MIDLA KETCH IPMOR SAILS BRIGG OPEGA BONGS</Route>
+            <Position Latitude="-31.957319" Longitude="115.960094" Speed="1" Altitude="69" />
+            <FlightPlan Departure="YPPH" Destination="OTHH" Alternative="" Active="true" Rules="I" CruiseSpeed="484" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">OPEGA1/03 OPEGA DCT BONGS/N0498F360 DCT 20S105E 13S100E 07S095E 06S094E/N0490F380 04S092E DCT ELATI N640 CL/N0484F400 N640 KAT P570 BASUR/M084F400 P570 KITAL/N0481F380 P570 EMURU N563 UMIBU P899 MEKRI/N0470F320 P899 MEKMA </FlightPlan>
+            <Route>OPEGA BONGS</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ1334" Type="B738" Delay="0">
             <Squawk Code="3542" ModeC="true" />
             <Cleared Level="36000" />
-            <Position Latitude="-29.600000000000005" Longitude="123.66599999999998" Speed="450" Altitude="36000" />
-            <FlightPlan Departure="YBBN" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="451" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CS J64 AS DCT AYE Q41 HAMTN Q158 BEVLY DCT </FlightPlan>
-            <Route>KG NALAR BIRER HAMTN BEVLY</Route>
+            <Position Latitude="-29.6" Longitude="123.666" Speed="450" Altitude="36000" />
+            <FlightPlan Departure="YBBN" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="451" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CS J64 AS DCT AYE Q41 MALUP Q158 KABLI DCT </FlightPlan>
+            <Route>KG NALAR BIRER MALUP KABLI</Route>
           </Aircraft>
           <Aircraft Callsign="QFA771" Type="B738" Delay="0">
             <Squawk Code="3544" ModeC="true" />
             <Cleared Level="38000" />
-            <Position Latitude="-35.599999999999994" Longitude="123.37000000000002" Speed="450" Altitude="38000" />
-            <FlightPlan Departure="YMML" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="451" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ESDIG V126 NOGIP T65 TEKUP L513 TAPAX Q27 HAMTN Q158 BEVLY DCT</FlightPlan>
-            <Route>MOLGA TAMOD HAMTN BEVLY</Route>
+            <Position Latitude="-35.6" Longitude="123.37" Speed="450" Altitude="38000" />
+            <FlightPlan Departure="YMML" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="451" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ESDIG V126 NOGIP T65 TEKUP L513 TAPAX Q27 MALUP Q158 KABLI DCT</FlightPlan>
+            <Route>MOLGA TAMOD MALUP KABLI</Route>
           </Aircraft>
           <Aircraft Callsign="JST106" Type="A320" Delay="1200" StartAuto="true">
             <Squawk Code="6457" ModeC="true" />
             <Cleared Level="18000" />
-            <Position Latitude="-31.957319" Longitude="115.96009399999998" Speed="1" Altitude="69" />
-            <FlightPlan Departure="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="484" ETD="0000" ATD="0000" RFL="33000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">AVNEX5/03 AVNEX Y15 ESDEG/N0456F340 Q587 SURFF/M077F340 Q587 METUM R592 PUPIT/N0456F340 R592 GIWOT DCT JALAK/N0454F330 DCT</FlightPlan>
-            <Route>MIDLA ANCOR BUDMA AVPES HARBY SAKOM VENUP AVNEX ESDEG WOLGO PADRY</Route>
+            <Position Latitude="-31.957319" Longitude="115.960094" Speed="1" Altitude="69" />
+            <FlightPlan Departure="YPPH" Destination="WADD" Alternative="" Active="true" Rules="I" CruiseSpeed="484" ETD="0000" ATD="0000" RFL="33000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">AVNEX5/03 AVNEX Y15 ESDEG/N0456F340 Q587 METUM R592 PUPIT/N0456F340 R592 GIWOT DCT JALAK/N0454F330 DCT</FlightPlan>
+            <Route>AVNEX ESDEG WOLGO PADRY</Route>
           </Aircraft>
           <Aircraft Callsign="NWK1613" Type="A320" Delay="0">
             <Squawk Code="2000" ModeC="false" />
@@ -4997,15 +4977,15 @@
             <Route>HINDS CALIG JULIM</Route>
             <TimedMessages>
               <TimedMessage Time="840" Message="NWK1613, IFR A320, Taxis Geraldton for Perth, Runway 03" />
-              <TimedMessage Time="1320" Message="Takeoff" />
+              <TimedMessage Time="1320" Message="Select Runway 03, Climb to F125, and Takeoff" />
             </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="RXA2113" Type="SF34" Delay="180" StartAuto="true">
             <Squawk Code="6457" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-31.957319" Longitude="115.96009399999998" Speed="0" Altitude="69" />
-            <FlightPlan Departure="YPPH" Destination="YABA" Alternative="" Active="true" Rules="I" CruiseSpeed="310" ETD="0000" ATD="0000" RFL="19000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">SOLUS6/03 SOLUS W172 ABA DCT </FlightPlan>
-            <Route>MIDLA GALLI SWANN JANDO MOCUR SOLUS JOSBU ABA</Route>
+            <FlightPlan Departure="YPPH" Destination="YABA" Alternative="" Active="true" Rules="I" CruiseSpeed="310" ETD="0000" ATD="0000" RFL="19000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">SOLUS6/03 SOLUS W172 JOSBU V408 ABA DCT </FlightPlan>
+            <Route>SOLUS JOSBU ARUMI ABA</Route>
           </Aircraft>
           <Aircraft Callsign="NWK1601" Type="A320" Delay="0">
             <Squawk Code="3064" ModeC="true" />
@@ -5211,17 +5191,17 @@
             <Route>TEMIS LACEY COLDS MONTY ESDAN</Route>
             <TimedMessages>
             <TimedMessage Time="300" Message="Ambulance 213, Kingair, POB 3, IFR, Taxiing Mt Hotham for Essendon, Runway 11" />
-            <TimedMessage Time="360" Message="Takeoff" />
+            <TimedMessage Time="360" Message="Select Runway 11, Climb to F125, and Takeoff" />
           </TimedMessages>
           </Aircraft>
-          <Aircraft Callsign="QLK2039D" Type="DH8D" Delay="0">
+          <Aircraft Callsign="QLK39D" Type="DH8D" Delay="0">
             <Squawk Code="2000" ModeC="false" />
             <Position Latitude="-36.065455" Longitude="146.96967" Speed="0" Altitude="538" />
             <FlightPlan Active="false" Departure="YMAY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="220" ETD="0000" ATD="0000" RFL="18000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DUGGI1/25 DUGGI V147 TEMIS V169 ML DCT</FlightPlan>
             <Route>SAPAN NIRIL DUGGI TEMIS BOYSE</Route>
             <TimedMessages>
-            <TimedMessage Time="400" Message="Qlink 2039 Delta, Dash 8 Delta, IFR, Taxiing Albury for Melbourne, Runway 25" />
-            <TimedMessage Time="460" Message="Ready at the Holding Point" />
+            <TimedMessage Time="200" Message="Qlink 2039 Delta, Dash 8 Delta, IFR, Taxiing Albury for Melbourne, Runway 25" />
+            <TimedMessage Time="450" Message="Select Runway 25, Climb To A085, and Takeoff" />
           </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="VOZ625" Type="B738" Delay="750" StartAuto="true">
@@ -5329,8 +5309,8 @@
             <FlightPlan Active="false" Departure="YBRK" Destination="YBBN" Alternative="YBCG" Rules="I" CruiseSpeed="400" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="CALL/VELOCITY    /v/">DCT BUDGI V111 RUROX Y177 SMOKA</FlightPlan>
             <Route>BUDGI RUROX NIROK LAMUG SMOKA YBBN</Route>
             <TimedMessages>
-            <TimedMessage Time="1080" Message="Velocity 1238, 737, IFR, Taxiing Rockhampton for Brisbane, Runway 33" />
-            <TimedMessage Time="1140" Message="Takeoff" />
+            <TimedMessage Time="900" Message="Velocity 1238, 737, IFR, Taxiing Rockhampton for Brisbane, Runway 33" />
+            <TimedMessage Time="1100" Message="Ready Runway 33, Request Clearance" />
           </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="FD436" Type="BE20" Delay="0">
@@ -5368,7 +5348,7 @@
             <Route>TUCAB TUCKI GOMOL MAKRU RULUN ITIDE YBSU</Route>
             <TimedMessages>
             <TimedMessage Time="900" Message="Bonza 45, 737, IFR, Taxiing Coffs Harbour for Sunny Coast, Runway 03" />
-            <TimedMessage Time="960" Message="Takeoff" />
+            <TimedMessage Time="960" Message="Select Runway 03, Climb to A085, and Takeoff" />
           </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="JST814" Type="A320" Delay="0">

--- a/ScenarioFiles.xml
+++ b/ScenarioFiles.xml
@@ -475,7 +475,7 @@
             <Cleared Approach="true" />
             <Position Latitude="-34.23666667" Longitude="150.52638889" Speed="200" Altitude="3000" />
             <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>SOSIJ RWY34L YSSY</Route>
+            <Route>BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ871" Type="B738" Delay="0">
             <Squawk Code="1237" ModeC="true" />
@@ -701,7 +701,7 @@
             <Cleared Approach="true" />
             <Position Latitude="-34.23666667" Longitude="150.52638889" Speed="200" Altitude="3000" />
             <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>SOSIJ RWY34L YSSY</Route>
+            <Route>BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ871" Type="B738" Delay="0">
             <Squawk Code="1237" ModeC="true" />

--- a/ScenarioFiles.xml
+++ b/ScenarioFiles.xml
@@ -409,13 +409,13 @@
           <Aircraft Callsign="JST37" Type="B788" Delay="0">
             <Squawk Code="2000" ModeC="false" />
             <Position Latitude="-33.93904799999999" Longitude="151.169797" Speed="0" Altitude="13" />
-            <FlightPlan Departure="YSSY" Destination="WADD" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT RIC UH226 ENPAG T74 NONET/N0476F430 T74 VINAX G326 NYOMA DCT</FlightPlan>
+            <FlightPlan Departure="YSSY" Destination="WADD" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT RIC H226 ENPAG T74 NONET/N0476F430 T74 VINAX G326 NYOMA DCT</FlightPlan>
             <Route>RIC BOYSY IDSUP EMROT MUDGI UNSAR WADD</Route>
           </Aircraft>
           <Aircraft Callsign="THA476" Type="B744" Delay="0">
             <Squawk Code="2000" ModeC="false" />
             <Position Latitude="-33.939237" Longitude="151.16663600000004" Speed="0" Altitude="13" />
-            <FlightPlan Departure="YSSY" Destination="VTBS" Alternative="" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="34000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT RIC UH226 ENPAG T74 KARAG/N0500F340 T74 VINAX/N0500F360 T74 TN J251 DN M768 PORAK/N0490F380 M768 TSN R468 PNH A340 RYN DCT</FlightPlan>
+            <FlightPlan Departure="YSSY" Destination="VTBS" Alternative="" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="34000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT RIC H226 ENPAG T74 KARAG/N0500F340 T74 VINAX/N0500F360 T74 TN J251 DN M768 PORAK/N0490F380 M768 TSN R468 PNH A340 RYN DCT</FlightPlan>
             <Route>RIC ENPAG VEPAP NONET VINAX DOTAP VTBS</Route>
           </Aircraft>
           <Aircraft Callsign="QLK227D" Type="DH8D" Delay="0">
@@ -618,7 +618,7 @@
           <Aircraft Callsign="UAE476" Type="B772" Delay="0" StartAuto="false">
               <Squawk Code="2000" ModeC="false" />
               <Position Latitude="-33.939237" Longitude="151.16663600000004" Speed="0" Altitude="13" />
-              <FlightPlan Departure="YSSY" Destination="OMDB" Alternative="" Active="false" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="34000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT RIC UH226 ENPAG T74 KARAG/N0500F340 T74 VINAX/N0500F360 T74 TN J251 DN M768 PORAK/N0490F380 M768 TSN R468 PNH A340 RYN DCT</FlightPlan>
+              <FlightPlan Departure="YSSY" Destination="OMDB" Alternative="" Active="false" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="34000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT RIC H226 ENPAG T74 KARAG/N0500F340 T74 VINAX/N0500F360 T74 TN J251 DN M768 PORAK/N0490F380 M768 TSN R468 PNH A340 RYN DCT</FlightPlan>
               <Route>RIC</Route>
               <TimedMessages>
                   <TimedMessage Time="45" Message="Request clearance to Dubai (bay 55)" />
@@ -892,7 +892,7 @@
         <Aircraft Callsign="VOZ1115" Type="B738" Delay="0">
           <Squawk Code="2000" ModeC="false" />
           <Position Latitude="-27.386573" Longitude="153.120434" Speed="0" Altitude="20" />
-          <FlightPlan Departure="YBBN" Destination="YBPN" Alternative="" Active="false" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT BIXAD Q67 CAPRI UQ493 EMSUP V308 MK DCT PN DCT</FlightPlan>
+          <FlightPlan Departure="YBBN" Destination="YBPN" Alternative="" Active="false" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT BIXAD Q67 CAPRI Q493 EMSUP V308 MK DCT PN DCT</FlightPlan>
           <Route>BIXAD CAPRI EMSUP MK PN</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ310" Type="B738" Delay="0">
@@ -1119,7 +1119,7 @@
         <Aircraft Callsign="VOZ1113" Type="B738" Delay="0">
           <Squawk Code="2000" ModeC="false" />
           <Position Latitude="-27.386573" Longitude="153.120434" Speed="0" Altitude="20" />
-          <FlightPlan Departure="YBBN" Destination="YBPN" Alternative="" Active="false" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT BIXAD Q67 CAPRI UQ493 EMSUP V308 MK DCT PN DCT</FlightPlan>
+          <FlightPlan Departure="YBBN" Destination="YBPN" Alternative="" Active="false" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT BIXAD Q67 CAPRI Q493 EMSUP V308 MK DCT PN DCT</FlightPlan>
           <Route>BIXAD CAPRI EMSUP MK PN</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ308" Type="B738" Delay="0">
@@ -1413,7 +1413,7 @@
 	<Aircraft Callsign="JST746" Type="A320" Delay="0" StartAuto="false">
       <Squawk Code="2000" ModeC="false" />
       <Position Latitude="-41.5425" Longitude="147.206111" Speed="0" Altitude="550" />
-      <FlightPlan Departure="YMLT" Destination="YSSY" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="30" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVFU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DCT VIMAP UY327 MAKRL J163 CB W423 CULIN Y59 RIVET DCT</FlightPlan>
+      <FlightPlan Departure="YMLT" Destination="YSSY" Alternative="" Active="false" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="30" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVFU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DCT VIMAP Y327 MAKRL J163 CB W423 CULIN Y59 RIVET DCT</FlightPlan>
       <Route>VIMAP</Route>
 	  <TimedMessages>
         <TimedMessage Time="240" Message="'Launy Tower, JST746, for Sydney, Request Clearance'" />
@@ -2122,7 +2122,7 @@
               <Squawk Code="2202" ModeC="true" />
               <Position Latitude="-27.358423" Longitude="153.120866" Speed="1" Altitude="20" />
               <Cleared Level="6000" />
-              <FlightPlan Active="true" Departure="YBBN" Destination="YBPN" Alternative="" Rules="1" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">BIXAD1/19R BIXAD Q67 RUNLA UQ493 EMSUP V308 MK DCT PN DCT</FlightPlan>
+              <FlightPlan Active="true" Departure="YBBN" Destination="YBPN" Alternative="" Rules="1" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">BIXAD1/19R BIXAD Q67 RUNLA Q493 EMSUP V308 MK DCT PN DCT</FlightPlan>
               <Route>BIXAD GUDSO</Route>
               <TimedMessages>
                 <TimedMessage Time="2390" Message="Takeoff" />
@@ -2224,7 +2224,7 @@
               <Squawk Code="4134" ModeC="true" />
               <Position Latitude="-25.916" Longitude="151.666" Speed="450" Altitude="33000" />
               <Cleared Level="3000" />
-              <FlightPlan Active="true" Departure="YPDN" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PALGA DCT NERTI J138 SURVO/N0458F370 J138 NTN T13 DOLIB/N0453F390 T13 EML UY409 BESBO Y177 SMOKA SMOK1A/19R</FlightPlan>
+              <FlightPlan Active="true" Departure="YPDN" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PALGA DCT NERTI J138 SURVO/N0458F370 J138 NTN T13 DOLIB/N0453F390 T13 EML Y409 BESBO Y177 SMOKA SMOK1A/19R</FlightPlan>
               <Route>LAMUG SMOKA RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="ANG3" Type="B763" Delay="90" StartAuto="true">
@@ -2245,7 +2245,7 @@
               <Squawk Code="4103" ModeC="true" />
               <Position Latitude="-28.2" Longitude="153.22" Speed="400" Altitude="21000" />
               <Cleared Level="3000" />
-              <FlightPlan Active="true" Departure="YMHB" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT LATUM H111 LT W218 VIMAP/N0454F370 UY327 MAKRL/N0454F380 J163 CB W137 AVBEG W184 MUDGI/N0455F390 H66 BLAKA BLAK5A/19L</FlightPlan>
+              <FlightPlan Active="true" Departure="YMHB" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT LATUM H111 LT W218 VIMAP/N0454F370 Y327 MAKRL/N0454F380 J163 CB W137 AVBEG W184 MUDGI/N0455F390 H66 BLAKA BLAK5A/19L</FlightPlan>
               <Route>DOGMU LAGEV PUBIV ISPON OMGUV BETSO RWY19L</Route>
             </Aircraft>
             <Aircraft Callsign="QFA1930" Type="E190" Delay="300" StartAuto="true">
@@ -2438,7 +2438,7 @@
             <Squawk Code="2211" ModeC="true" />
             <Position Latitude="-37.143527" Longitude="145.905625" Speed="190" Altitude="8000" />
             <Cleared Level="8000" />
-            <FlightPlan Active="true" Departure="YHOT" Destination="YMMB" Alternative="" Rules="1" CruiseSpeed="180" ETD="0000" ATD="0000" RFL="8000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">YHOT Z82 TEMIS W188 COLDS MB</FlightPlan>
+            <FlightPlan Active="true" Departure="YHOT" Destination="YMMB" Alternative="" Rules="1" CruiseSpeed="180" ETD="0000" ATD="0000" RFL="8000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT OMBIS Z82 TEMIS W188 COLDS MB</FlightPlan>
             <Route>TEMIS LACEY COLDS MB</Route>
             <TimedMessages>
               <TimedMessage Time="800" Message="Coord ELW to ML APP. Via LACEY, HUT." />
@@ -2660,7 +2660,7 @@
           
         - **BNZ1023** departs to conflict with **JST611**
 
-        - **ANZ1984** departs Runway 16 **Off-Mode**. Feel free to add some personality to your radio calls, extend your "uuuhhhh" in your call, make some comments about the wind or turbulence, advise your planned mach number, you know the drill
+        - **ANZ1984** departs Runway 16 **Off-Mode**. Feel free to add some personality to your radio calls, extend your "uuHhhh" in your call, make some comments about the wind or turbulence, advise your planned mach number, you know the drill
 
         - This is shortly followed by **QFA7354** (a B462) in front of a faster following **QFA490** (A332). All 3 aircraft require separation management
 
@@ -3745,7 +3745,7 @@
       <Squawk Code="1164" ModeC="true" />
       <Cleared Level="10000" Approach="false" />
       <Position Latitude="-34.051667" Longitude="152.241389" Speed="270" Altitude="14000" />
-      <FlightPlan Departure="YLHI" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="254" ETD="0000" ATD="0000" RFL="140" EETHours="2" EETMins="25" FuelHours="3" FuelMins="15" Remarks="PBN/A1S1 NAV/RNP2 DOF/240101 REG/VHTQG OPR/QANTASLINK ORGN/YSSYQFAO PER/B /V/">DCT LHI UH258 RIKNI N774 MARLN MARLN5/16L</FlightPlan>
+      <FlightPlan Departure="YLHI" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="254" ETD="0000" ATD="0000" RFL="140" EETHours="2" EETMins="25" FuelHours="3" FuelMins="15" Remarks="PBN/A1S1 NAV/RNP2 DOF/240101 REG/VHTQG OPR/QANTASLINK ORGN/YSSYQFAO PER/B /V/">DCT LHI H258 RIKNI N774 MARLN MARLN5/16L</FlightPlan>
       <Route>MARLN RWY16L</Route>
     </Aircraft>
 	<Aircraft Callsign="FD233" Type="BE20" Delay="0" StartAuto="false">
@@ -3851,7 +3851,7 @@
           <Squawk Code="3122" ModeC="true" />
           <Cleared Level="8000" />
           <Position Latitude="-41.537372999999995" Longitude="147.204273" Speed="1" Altitude="558" />
-          <FlightPlan Active="true" Departure="YMLT" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="430" ETD="0000" ATD="0000" RFL="35000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">VIMA1B/14R VIMAP UY327 MAKRL J163 CB W423 CULIN Y59 TESAT DCT</FlightPlan>
+          <FlightPlan Active="true" Departure="YMLT" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="430" ETD="0000" ATD="0000" RFL="35000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">VIMA1B/14R VIMAP Y327 MAKRL J163 CB W423 CULIN Y59 TESAT DCT</FlightPlan>
           <Route>VIMAP NIFTI</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ1090" Type="B738" Delay="0">
@@ -3920,7 +3920,7 @@
           <Squawk Code="1231" ModeC="true" /> 
           <Cleared Level="4500" />
           <Position Latitude="-42.829504" Longitude="147.502539" Speed="1" Altitude="20" />
-          <FlightPlan Active="true" Departure="YMHB" Destination="YSCB" Alternative="" Rules="I" CruiseSpeed="275" ETD="0000" ATD="0000" RFL="18000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">KANLI3/12 KANLI H111 LT W218 VIMAP UY327 MAKRL POLLI CB DCT</FlightPlan>
+          <FlightPlan Active="true" Departure="YMHB" Destination="YSCB" Alternative="" Rules="I" CruiseSpeed="275" ETD="0000" ATD="0000" RFL="18000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">KANLI3/12 KANLI H111 LT W218 VIMAP Y327 MAKRL POLLI CB DCT</FlightPlan>
           <Route>OREBA ISTIG OMKUL GIVOT SORVI TOSUG VILAL MIBAL KANLI LT VIMAP MAKRL POLLI YSCB</Route>
         </Aircraft>
         <Aircraft Callsign="QJE1554" Type="B712" Delay="400" StartAuto="true">
@@ -4118,8 +4118,8 @@
       <Squawk Code="1141" ModeC="true" />
       <Cleared Level="24000" Approach="false" />
       <Position Latitude="-34.958056" Longitude="138.517778" Speed="0" Altitude="33" />
-      <FlightPlan Departure="YPAD" Destination="YOLD" Alternative="" Active="true" Equipment="SDGHIRWYZ/LB1" Rules="I" CruiseSpeed="430" ETD="0000" ATD="0000" RFL="320" EETHours="00" EETMins="45" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/230117 REG/VHUZK EET/YBBB0108 SEL/EQHK CODE/7C68CE OPR/ALLIANCE ORGN/YSSYQFAO PER/C /V/ ">AREPA1/05 AREPA J58 WHA W566 YOLD</FlightPlan>
-      <Route>AREPA SPOTA WHA POLUP YOLD</Route>
+      <FlightPlan Departure="YPAD" Destination="YOLD" Alternative="" Active="true" Equipment="SDGHIRWYZ/LB1" Rules="I" CruiseSpeed="430" ETD="0000" ATD="0000" RFL="320" EETHours="00" EETMins="45" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/230117 REG/VHUZK EET/YBBB0108 SEL/EQHK CODE/7C68CE OPR/ALLIANCE ORGN/YSSYQFAO PER/C /V/ ">AREPA1/05 AREPA J58 WHA W566 GOKIB DCT</FlightPlan>
+      <Route>AREPA SPOTA WHA POLUP GOKIB YOLD</Route>
 	  <TimedMessages>
       <TimedMessage Time="330" Message="Takeoff" />
 		  <TimedMessage Time="650" Message="Set Vertical Speed to 1000ft/min" />
@@ -4174,7 +4174,7 @@
 	  <Squawk Code="2344" ModeC="true" />
 	  <Cleared Level="31000" />
 	  <Position Latitude="-32.882222" Longitude="132.742222" Speed="465" Altitude="31000" />
-	  <FlightPlan Active="true" Departure="YPPH" Destination="YSSY" Alternative="" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="31000" EETHours="08" EETMins="20" FuelHours="9" FuelMins="50" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 RNVD1A1 SUR/260B DOF/240101 REG/VHEBO EET/YBBB0103 SEL/CEFS CODE/7C5325 OPR/QFA ORGN/YSSYQFAO PER/C /V/">DCT PH H18 MUBID J21 BORLI UH205 CULIN Y59 RIVET DCT</FlightPlan>
+	  <FlightPlan Active="true" Departure="YPPH" Destination="YSSY" Alternative="" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="31000" EETHours="08" EETMins="20" FuelHours="9" FuelMins="50" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 RNVD1A1 SUR/260B DOF/240101 REG/VHEBO EET/YBBB0103 SEL/CEFS CODE/7C5325 OPR/QFA ORGN/YSSYQFAO PER/C /V/">DCT PH H18 MUBID J21 BORLI H205 CULIN Y59 RIVET DCT</FlightPlan>
 	  <Route>ABTOD WHA KABEK IBABI UVUPU BORLI CULIN TARAL RIVET TESAT</Route>
 	  <TimedMessages>
       <TimedMessage Time="2220" Message="'QFA648, Request F390'" />
@@ -4366,7 +4366,7 @@
             <Squawk Code="6464" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-12.419272" Longitude="130.895323" Speed="1" Altitude="89" />
-            <FlightPlan Active="true" Departure="YPDN" Destination="YBAS" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="41000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">RUPEG1/29 RUPEG Y25 BEBUX UY83 GREGA J251 AS DCT</FlightPlan>
+            <FlightPlan Active="true" Departure="YPDN" Destination="YBAS" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="41000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">RUPEG1/29 RUPEG Y25 BEBUX Y83 GREGA J251 AS DCT</FlightPlan>
             <Route>RUPEG ADKIV BEBUX GREGA SCOTI AS</Route>
           </Aircraft>
           <Aircraft Callsign="ANO160" Type="E170" Delay="500" StartAuto="true">
@@ -4380,7 +4380,7 @@
             <Squawk Code="6222" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-12.419272" Longitude="130.895322" Speed="1" Altitude="89" />
-            <FlightPlan Active="true" Departure="YPDN" Destination="YPAD" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">RUPEG1/29 RUPEG Y25 BEBUX UY83 GREGA J251 SADEL/N0453F370 J251 WHA H84 AD</FlightPlan>
+            <FlightPlan Active="true" Departure="YPDN" Destination="YPAD" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">RUPEG1/29 RUPEG Y25 BEBUX Y83 GREGA J251 SADEL/N0453F370 J251 WHA H84 AD</FlightPlan>
             <Route>RUPEG ADKIV OPEKO BEBUX GREGA SCOTI AS</Route>
           </Aircraft>
           <Aircraft Callsign="ANO112" Type="E170" Delay="790" StartAuto="true">
@@ -4394,7 +4394,7 @@
             <Squawk Code="5747" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-12.419272" Longitude="130.895322" Speed="1" Altitude="89" />
-            <FlightPlan Active="true" Departure="YPDN" Destination="YBAS" Alternative="" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="35000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">RUPEG1/29 RUPEG Y25 BEBUX UY83 GREGA J251 AS</FlightPlan>
+            <FlightPlan Active="true" Departure="YPDN" Destination="YBAS" Alternative="" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="35000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">RUPEG1/29 RUPEG Y25 BEBUX Y83 GREGA J251 AS</FlightPlan>
             <Route>RUPEG ADKIV OPEKO BEBUX GREGA SCOTI AS</Route>
           </Aircraft>    
           <Aircraft Callsign="JFO" Type="C441" Delay="0">
@@ -4499,7 +4499,7 @@
               <Squawk Code="4510" ModeC="true" />
               <Cleared Level="8000" />
               <Position Latitude="-27.9" Longitude="151.83" Speed="140" Altitude="8000" />
-              <FlightPlan Departure="YBWW" Destination="YGDH" Alternative="" Active="true" Rules="I" CruiseSpeed="140" ETD="0000" ATD="0000" RFL="8000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">DCT UPMOG IVL W207 GDH DCT</FlightPlan>
+              <FlightPlan Departure="YBWW" Destination="YGDH" Alternative="" Active="true" Rules="I" CruiseSpeed="140" ETD="0000" ATD="0000" RFL="8000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">DCT UPMOG IVL W207 OLRON DCT</FlightPlan>
               <Route>IVL CFS</Route>
           </Aircraft>
           <Aircraft Callsign="SJD" Type="C182" Delay="0">
@@ -4527,8 +4527,8 @@
               <Squawk Code="4003" ModeC="true" />
               <Cleared Level="10000" />
               <Position Latitude="-32.1" Longitude="150.6333" Speed="150" Altitude="10000" />
-              <FlightPlan Departure="YSBK" Destination="YMOR" Alternative="" Active="true" Rules="I" CruiseSpeed="140" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">DCT BK DUUKE BOSUN QDI HARIZ NBR MOR</FlightPlan>
-              <Route>QDI HARIZ NBR MOR</Route>
+              <FlightPlan Departure="YSBK" Destination="YMOR" Alternative="" Active="true" Rules="I" CruiseSpeed="140" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">DCT BK DUUKE BOSUN NIXUG HARIZ NBR MOR</FlightPlan>
+              <Route>NIXUG HARIZ NBR MOR</Route>
               <TimedMessages>
                 <TimedMessage Time="2220" Message="Request traffic for DCT MRZSG Moree Sierra Golf for the RNP Runway 01." />
               </TimedMessages> 
@@ -4587,7 +4587,7 @@
               <Cleared Level="41000" />
               <Position Latitude="-24.750000000000004" Longitude="148.5" Speed="450" Altitude="41000" />
               <FlightPlan Departure="YBCS" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="480" ETD="0000" ATD="0000" RFL="41000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">DCT AKROM Y153 ROKUU H652 BOREE DCT  </FlightPlan>
-              <Route>KANKO ROKUU PEXUM EMTEL VIREN SCO IGDAM SADLO BOREE</Route>
+              <Route>KANKO ROKUU PEXUM EMTEL VIREN LALIB IGDAM SADLO BOREE</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ1392" Type="B738" Delay="0">
               <Squawk Code="4021" ModeC="true" />
@@ -4607,15 +4607,15 @@
               <Squawk Code="4017" ModeC="true" />
               <Cleared Level="37000" />
               <Position Latitude="-28.688611" Longitude="149.191389" Speed="450" Altitude="37000" />
-              <FlightPlan Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="490" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">OCEAN V4 NOMAN A461 AVMUP W16 MIA LIGPA B472 TOREX IDELU GV GUGUK VATKO ONELU SGE Y161 OVNOM H652 BOREE DCT</FlightPlan>
-              <Route>OTLAM OVNOM SCO IGDAM BOREE</Route>
+              <FlightPlan Departure="WSSS" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="490" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">OCEAN V4 NOMAN A461 AVMUP W16 MIA LIGPA B472 TOREX IDELU GV GUGUK VATKO ONELU SGE Y161 OVNOM H652 BOREE DCT</FlightPlan>
+              <Route>OTLAM OVNOM LALIB IGDAM BOREE</Route>
           </Aircraft>
           <Aircraft Callsign="JAL51" Type="B773" Delay="0">
               <Squawk Code="4010" ModeC="true" />
               <Cleared Level="41000" />
               <Position Latitude="-28.495554999999996" Longitude="149.769444" Speed="450" Altitude="41000" />
-              <FlightPlan Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="490" ETD="0000" ATD="0000" RFL="41000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">DCT VAMOS DCT XAC B586 UKATA DCT 25N141E/N0483F400 DCT 20N141E/M084F400 DCT 15N141E/M084F410 DCT 10N142E DCT 05N143E DCT FACED/N0482F410 A216 CS Y177 AKROM Y153 ROKUU H652 BOREE/M082F410 DCT</FlightPlan>
-              <Route>AKOGO PEXUM EMTEL VIREN SCO IGDAM SADLO BOREE</Route>
+              <FlightPlan Destination="RJAA" Alternative="" Active="true" Rules="I" CruiseSpeed="490" ETD="0000" ATD="0000" RFL="41000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">DCT VAMOS DCT XAC B586 UKATA DCT 25N141E/N0483F400 DCT 20N141E/M084F400 DCT 15N141E/M084F410 DCT 10N142E DCT 05N143E DCT FACED/N0482F410 A216 CS Y177 AKROM Y153 ROKUU H652 BOREE/M082F410 DCT</FlightPlan>
+              <Route>AKOGO PEXUM EMTEL VIREN LALIB IGDAM SADLO BOREE</Route>
           </Aircraft>
           <Aircraft Callsign="QFA840" Type="B738" Delay="0">
               <Squawk Code="4011" ModeC="true" />
@@ -4732,14 +4732,14 @@
           <Squawk Code="4045" ModeC="true" />
           <Cleared Level="41000" />
           <Position Latitude="-29.95" Longitude="136.33" Speed="450" Altitude="41000" />
-          <FlightPlan Departure="YPDN" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="41000" EETHours="02" EETMins="30" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 PER/C/v/">DCT PALGA Y25 BEBUX UY83 GREGA J251 WHA H84 AD DCT</FlightPlan>
+          <FlightPlan Departure="YPDN" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="41000" EETHours="02" EETMins="30" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 PER/C/v/">DCT PALGA Y25 BEBUX Y83 GREGA J251 WHA H84 AD DCT</FlightPlan>
           <Route>WR OJJAY WHA SEDRA ASILI MARGO AD</Route>
         </Aircraft>
         <Aircraft Callsign="JST694" Type="A320" Delay="0">
           <Squawk Code="4046" ModeC="true" />
           <Cleared Level="37000" />
           <Position Latitude="-29.68" Longitude="136.235" Speed="450" Altitude="37000" />
-          <FlightPlan Departure="YPDN" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="37000" EETHours="02" EETMins="30" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 PER/C/v/">DCT PALGA Y25 BEBUX UY83 GREGA J251 WHA H84 AD DCT</FlightPlan>
+          <FlightPlan Departure="YPDN" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="37000" EETHours="02" EETMins="30" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 PER/C/v/">DCT PALGA Y25 BEBUX Y83 GREGA J251 WHA H84 AD DCT</FlightPlan>
           <Route>WR OJJAY WHA SEDRA ASILI MARGO AD</Route>
         </Aircraft>
         <Aircraft Callsign="QFA661" Type="B738" Delay="0">
@@ -4854,14 +4854,14 @@
             <Squawk Code="1011" ModeC="true" />
             <Cleared Level="20000" />
             <Position Latitude="-29.790000000000006" Longitude="123.29999999999998" Speed="250" Altitude="20000" />
-            <FlightPlan Departure="YAYE" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="270" ETD="0000" ATD="0000" RFL="20000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT AYE Q41 KG V242 KELLA Z38 GRENE DCT</FlightPlan>
-            <Route>KG GIVEB KELLA BOOKA MESAM</Route>
+            <FlightPlan Departure="YAYE" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="270" ETD="0000" ATD="0000" RFL="20000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT AYE Q41 KG V242 KELLA Z38 LAVEX DCT</FlightPlan>
+            <Route>KG GIVEB KELLA LAVEX</Route>
           </Aircraft>
           <Aircraft Callsign="QFA644" Type="B738" Delay="1380" StartAuto="true">
             <Squawk Code="2001" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-31.957319" Longitude="115.96009399999998" Speed="1" Altitude="69" />
-            <FlightPlan Departure="YPPH" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="453" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">MUBID3/03 MUBID J21 ABTOD/M081F410 J21 BORLI UH205 CULIN Y59 RIVET DCT</FlightPlan>
+            <FlightPlan Departure="YPPH" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="453" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">MUBID3/03 MUBID J21 ABTOD/M081F410 J21 BORLI H205 CULIN Y59 RIVET DCT</FlightPlan>
             <Route>MUBID OLRUX IVPEM</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ684" Type="B738" Delay="2220" StartAuto="true">
@@ -4912,9 +4912,9 @@
           <Aircraft Callsign="NTE" Type="BE20" Delay="1800" StartAuto="true">
             <Squawk Code="4340" ModeC="true" />
             <Cleared Level="18000" />
-            <Position Latitude="-30.7894" Longitude="121.46159999999999" Speed="1" Altitude="1184" />
-            <FlightPlan Departure="YPKG" Destination="YPPH" Alternative="" Active="true" Rules="I" CruiseSpeed="265" ETD="0000" ATD="0000" RFL="18000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">YPKG/11 DCT KG V242 KELLA Z38 GRENE DCT</FlightPlan>
-            <Route>GIVEB KELLA GRENE BOOKA MESAM</Route>
+            <Position Latitude="-30.7894" Longitude="121.4616" Speed="1" Altitude="1184" />
+            <FlightPlan Departure="YPKG" Destination="YPJT" Alternative="" Active="true" Rules="I" CruiseSpeed="265" ETD="0000" ATD="0000" RFL="18000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">YPKG/11 DCT KG V242 KELLA Z38 PH W114 JT DCT</FlightPlan>
+            <Route>GIVEB KELLA LAVEX PH JT</Route>
           </Aircraft>
           <Aircraft Callsign="MOO" Type="PC12" Delay="0">
             <Squawk Code="3102" ModeC="true" />
@@ -5521,7 +5521,7 @@
                   <Squawk Code="6220" ModeC="true" />
                   <Cleared Level="35000" />
                   <Position Latitude="-42.435" Longitude="151.471944" Speed="432" Altitude="35000" />
-                  <FlightPlan Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Departure="YPPH" Destination="NZAA" Alternative="" Rules="I" CruiseSpeed="432" ETD="0000" ATD="0000" RFL="35000" EETHours="06" EETMins="30" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1L1O1S2T1 NAV/RNP2 /v/">DCT PH H18 BURGU Y53 MEMUP UY87 TAPAX L513 TASUM L513 AA DCT</FlightPlan>
+                  <FlightPlan Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Departure="YPPH" Destination="NZAA" Alternative="" Rules="I" CruiseSpeed="432" ETD="0000" ATD="0000" RFL="35000" EETHours="06" EETMins="30" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1L1O1S2T1 NAV/RNP2 /v/">DCT PH H18 BURGU Y53 MEMUP Y87 TAPAX L513 TASUM L513 AA DCT</FlightPlan>
                   <Route>KAGRI TUVBI MIDAT UNTET VELMO AA</Route>
                 </Aircraft> 
             <Aircraft Callsign="AWK7" Type="B733" Delay="0">

--- a/ScenarioFiles.xml
+++ b/ScenarioFiles.xml
@@ -446,43 +446,43 @@
             <Squawk Code="1234" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.51250000" Longitude="149.90805556" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA490" Type="B738" Delay="0">
             <Squawk Code="1236" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.02166667" Longitude="151.00444444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
             <Route>DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="JST522" Type="A320" Delay="0">
             <Squawk Code="1235" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.14750000" Longitude="151.09444444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
             <Route>NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA464" Type="B738" Delay="0">
             <Squawk Code="3134" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.38166667" Longitude="150.20888889" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="TGG264" Type="B738" Delay="0">
             <Squawk Code="4265" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.23666667" Longitude="150.52638889" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <Route>RWY34L SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ871" Type="B738" Delay="0">
             <Squawk Code="1237" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.12638889" Longitude="150.77194444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <Route>TAMMI RWY34L SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA543" Type="B738" Delay="0">
             <Squawk Code="5234" ModeC="true" />
@@ -502,8 +502,8 @@
             <Squawk Code="2646" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.62722222" Longitude="149.64916667" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="JST821" Type="B738" Delay="0">
             <Squawk Code="5373" ModeC="true" />
@@ -672,43 +672,43 @@
             <Squawk Code="1234" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.51250000" Longitude="149.90805556" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA490" Type="B738" Delay="0">
             <Squawk Code="1236" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.02166667" Longitude="151.00444444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
             <Route>DUDOK NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="JST522" Type="A320" Delay="0">
             <Squawk Code="1235" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.14750000" Longitude="151.09444444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
             <Route>NASHO SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA464" Type="B738" Delay="0">
             <Squawk Code="3134" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.38166667" Longitude="150.20888889" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="TGG264" Type="B738" Delay="0">
             <Squawk Code="4265" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.23666667" Longitude="150.52638889" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <Route>RWY34L SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ871" Type="B738" Delay="0">
             <Squawk Code="1237" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.12638889" Longitude="150.77194444" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <Route>TAMMI RWY34L SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="QFA543" Type="B738" Delay="0">
             <Squawk Code="5234" ModeC="true" />
@@ -728,8 +728,8 @@
             <Squawk Code="2646" ModeC="true" />
             <Cleared Approach="true" />
             <Position Latitude="-34.62722222" Longitude="149.64916667" Speed="200" Altitude="3000" />
-            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ YSSY/34L</FlightPlan>
-            <Route>RIVET BIGEM TAMMI BOOGI DUDOK NASHO SOSIJ RWY34L YSSY</Route>
+            <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RWY34L SOSIJ YSSY/34L</FlightPlan>
+            <Route>RIVET RWY34L SOSIJ RWY34L YSSY</Route>
           </Aircraft>
           <Aircraft Callsign="JST821" Type="B738" Delay="0">
             <Squawk Code="5373" ModeC="true" />
@@ -1746,7 +1746,7 @@
                 <Cleared Level="9000" />
                 <Position Latitude="-35.484521" Longitude="139.331039" Speed="350" Altitude="16000" />
                 <FlightPlan Departure="YMML" Destination="YPAD" Alternative="" Active="true" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="34000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H345 DRINA DRIN9A/23</FlightPlan>
-                <Route>DRINA COMLY DISHA BRAKI OMDIN GULLY RWY23</Route>
+                <Route>DRINA RWY23</Route>
             </Aircraft>
             <Aircraft Callsign="VOZ621" Type="B737" Delay="0">
                 <Squawk Code="3621" ModeC="true" />
@@ -2053,7 +2053,8 @@
               <FlightPlan Active="true" Departure="YBBN" Destination="YARM" Alternative="" Rules="1" CruiseSpeed="264" ETD="0000" ATD="0000" RFL="12000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">BN4/19L BN H91 HUUGO W128 ALDAR W786 ARM DCT</FlightPlan>
               <Route>SANEG HUUGO ALDAR</Route>
               <TimedMessages>
-                <TimedMessage Time="0" Message="Coord. VET, Next, Runway 19L" />
+                <TimedMessage Time="0" Message="Add SANEG to route before HUUGO" />
+                <TimedMessage Time="1" Message="BN ADC to BN APP Coord: 'Next, Runway 19L, VET'" />
                 <TimedMessage Time="50" Message="Takeoff" />
               </TimedMessages>
             </Aircraft>
@@ -2175,105 +2176,105 @@
               <Position Latitude="-29.3" Longitude="152.62" Speed="450" Altitude="41000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YSCB" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="41000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT AVBEG W184 MUDGI H66 BLAKA BLAK5A/19L</FlightPlan>
-              <Route>WHITI IDNER BLAKA DOGMU LAGEV PUBIV ISPON OMGUV BETSO</Route>
+              <Route>WHITI IDNER BLAKA RWY19L</Route>
             </Aircraft>
             <Aircraft Callsign="RXA258" Type="B738" Delay="480" StartAuto="true">
               <Squawk Code="4117" ModeC="true" />
               <Position Latitude="-29.8" Longitude="152.12" Speed="450" Altitude="37000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YMML" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT NONIX H66 BLAKA BLAK5A/19L</FlightPlan>
-              <Route>WHITI IDNER BLAKA DOGMU LAGEV PUBIV ISPON OMGUV BETSO</Route>          
+              <Route>WHITI IDNER BLAKA RWY19L</Route>          
             </Aircraft>
             <Aircraft Callsign="QLK2405" Type="DH8C" Delay="0">
               <Squawk Code="4102" ModeC="true" />
               <Position Latitude="-26.78" Longitude="152.77" Speed="300" Altitude="13000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YEML" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="340" ETD="0000" ATD="0000" RFL="25000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT EML W186 SUSGI V307 MORBI MORB2A/19R</FlightPlan>
-              <Route>REMOR GAYLA LUTKO IGBON PAMBU ATRAX LAVIN OSOKO</Route>
+              <Route>REMOR GAYLA LUTKO IGBON PAMBU ATRAX LAVIN OSOKO RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="QLK2455" Type="DH8C" Delay="360" StartAuto="true">
               <Squawk Code="4106" ModeC="true" />
               <Position Latitude="-26.185" Longitude="152.22" Speed="300" Altitude="23000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YMRB" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="344" ETD="0000" ATD="0000" RFL="23000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT NIPOM W727 SUSGI V307 MORBI MORB2A/19R</FlightPlan>
-              <Route>OTLEB MORBI REMOR GAYLA LUTKO IGBON PAMBU ATRAX LAVIN OSOKO</Route>
+              <Route>OTLEB MORBI RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="QFA787" Type="B738" Delay="720" StartAuto="true">
               <Squawk Code="4113" ModeC="true" />
               <Position Latitude="-26.06" Longitude="151.805" Speed="450" Altitude="29000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YBAS" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PULOL T11 ROM Y166 ROWLO V327 HAWKE Y340 LAMUG Y177 SMOKA SMOK1A/19R</FlightPlan>
-              <Route>LAMUG SMOKA OTGAT GARTH BURPA IGBON PAMBU ATRAX LAVIN OSOKO</Route>
+              <Route>LAMUG SMOKA RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="QFA987" Type="B738" Delay="180" StartAuto="true">
               <Squawk Code="4110" ModeC="true" />
               <Position Latitude="-26.2666" Longitude="152.0" Speed="450" Altitude="25000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YBMK" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT MUNAR Y61 RUROX Y177 SMOKA SMOK1A/19R</FlightPlan>
-              <Route>LAMUG SMOKA OTGAT GARTH BURPA IGBON PAMBU ATRAX LAVIN OSOKO</Route>
+              <Route>LAMUG SMOKA RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="VOZ465" Type="B738" Delay="660" StartAuto="true">
               <Squawk Code="4111" ModeC="true" />
               <Position Latitude="-28.37" Longitude="152.075" Speed="300" Altitude="25000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YPPH" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT MUBID J21 OLRUX DCT CDU DCT TILLI DCT SAPED DCT VAGPO DCT PASTA DCT AGETA DCT RACHL Y465 ENLIP ENLI2A/19R</FlightPlan>
-              <Route>ENLIP DULIN ALBUB RITVU APUKU DRAIN PAMBU ATRAX LAVIN OSOKO</Route>
+              <Route>ENLIP RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="VOZ448" Type="B738" Delay="1140" StartAuto="true">
               <Squawk Code="4134" ModeC="true" />
               <Position Latitude="-25.916" Longitude="151.666" Speed="450" Altitude="33000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YPDN" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PALGA DCT NERTI J138 SURVO/N0458F370 J138 NTN T13 DOLIB/N0453F390 T13 EML UY409 NIROK Y177 SMOKA SMOK1A/19R</FlightPlan>
-              <Route>LAMUG SMOKA OTGAT GARTH BURPA IGBON PAMBU ATRAX LAVIN OSOKO</Route>
+              <Route>LAMUG SMOKA RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="ANG3" Type="B763" Delay="90" StartAuto="true">
               <Squawk Code="4104" ModeC="true" />
               <Position Latitude="-26.415" Longitude="152.16" Speed="400" Altitude="21000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="AYPY" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="471" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PY/M080F370 B462 MK/N0472F370 V153 MUNAR Y61 RUROX Y177 SMOKA SMOK1A/19R</FlightPlan>
-              <Route>LAMUG SMOKA OTGAT GARTH BURPA IGBON PAMBU ATRAX LAVIN OSOKO</Route>
+              <Route>LAMUG SMOKA RWY19R</Route>
             </Aircraft>
             <Aircraft Callsign="VOZ943" Type="B738" Delay="0">
               <Squawk Code="4101" ModeC="true" />
               <Position Latitude="-28.16" Longitude="153.5" Speed="400" Altitude="21000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YSSY" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT OLSEM Y193 BANDA H252 GOMOL GOMO3A/19L</FlightPlan>
-              <Route>MEKUG SALEL SALGA ISPON OMGUV BETSO</Route>          
+              <Route>MEKUG SALEL SALGA ISPON OMGUV BETSO RWY19L</Route>          
             </Aircraft>
             <Aircraft Callsign="VOZ705" Type="B738" Delay="180" StartAuto="true">
               <Squawk Code="4103" ModeC="true" />
               <Position Latitude="-28.2" Longitude="153.22" Speed="400" Altitude="21000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YMHB" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT LATUM H111 LT W218 VIMAP/N0454F370 UY327 MAKRL/N0454F380 J163 CB W137 AVBEG W184 MUDGI/N0455F390 H66 BLAKA BLAK5A/19L</FlightPlan>
-              <Route>DOGMU LAGEV PUBIV ISPON OMGUV BETSO</Route>
+              <Route>DOGMU LAGEV PUBIV ISPON OMGUV BETSO RWY19L</Route>
             </Aircraft>
             <Aircraft Callsign="QFA1930" Type="E190" Delay="300" StartAuto="true">
               <Squawk Code="4105" ModeC="true" />
               <Position Latitude="-28.22" Longitude="152.275" Speed="400" Altitude="25000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YPAD" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT UPROT Y465 RACHL/M078F370 Y465 ENLIP ENLI2A/19L</FlightPlan>
-              <Route>ENLIP ODUTO ANSOR PULEX SORVA RUTAT PUBIV ISPON OMGUV BETSO</Route>
+              <Route>ENLIP RWY19L</Route>
             </Aircraft>
             <Aircraft Callsign="QLK2522" Type="DH8C" Delay="840" StartAuto="true">
               <Squawk Code="4107" ModeC="true" />
               <Position Latitude="-29.06" Longitude="153.06" Speed="340" Altitude="24000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YCFS" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="340" ETD="0000" ATD="0000" RFL="24000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT CFS W214 GOMOL GOMO3A/19L</FlightPlan>
-              <Route>GOMOL MEKUG SALEL SALGA ISPON OMGUV BETSO</Route>
+              <Route>GOMOL RWY19L</Route>
             </Aircraft>
             <Aircraft Callsign="JST7803" Type="A321" Delay="540" StartAuto="true">
               <Squawk Code="4112" ModeC="true" />
               <Position Latitude="-28.725" Longitude="151.71" Speed="450" Altitude="39000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YPAD" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT UPROT Y465 ENLIP ENLI2A/19L</FlightPlan>
-              <Route>ENLIP ODUTO ANSOR PULEX SORVA RUTAT PUBIV ISPON OMGUV BETSO</Route>
+              <Route>ENLIP RWY19L</Route>
             </Aircraft>
             <Aircraft Callsign="QFA616" Type="B738" Delay="720" StartAuto="true">
               <Squawk Code="4114" ModeC="true" />
               <Position Latitude="-29.18" Longitude="152.75" Speed="540" Altitude="39000" />
               <Cleared Level="3000" />
               <FlightPlan Active="true" Departure="YMML" Destination="YBBN" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT NONIX H66 BLAKA BLAK5A/19L</FlightPlan>
-              <Route>IDNER BLAKA DOGMU LAGEV PUBIV ISPON OMGUV BETSO</Route>
+              <Route>IDNER BLAKA RWY19L</Route>
             </Aircraft>
         </Targets>
     </ScenarioFile>
@@ -2308,63 +2309,63 @@
             <Position Latitude="-37.306667" Longitude="145.915" Speed="440" Altitude="24000" />
             <Cleared Level="9000" />
             <FlightPlan Active="true" Departure="YSSY" Destination="YMAV" Alternative="" Rules="1" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 RAZZI Q29 ML JAYBI5/18</FlightPlan>
-            <Route>LIZZI ML JAYBI BEKKA TEMPL</Route>
+            <Route>LIZZI ML JAYBI RWY18</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ876" Type="B738" Delay="0">
             <Squawk Code="4117" ModeC="true" />
             <Position Latitude="-37.202087" Longitude="146.119146" Speed="410" Altitude="24000" />
             <Cleared Level="9000" />
             <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="410" ETD="0000" ATD="0000" RFL="40000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-            <Route>LIZZI HORUS NEFER BELTA</Route>
+            <Route>LIZZI RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="QFA455" Type="A332" Delay="0">
             <Squawk Code="3111" ModeC="true" />
             <Position Latitude="-37.00189199999999" Longitude="146.500724" Speed="420" Altitude="26000" />
             <Cleared Level="9000" />
             <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-            <Route>LIZZI HORUS NEFER BELTA</Route>
+            <Route>LIZZI RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="QFA692" Type="B738" Delay="0">
             <Squawk Code="3002" ModeC="true" />
             <Position Latitude="-36.35500000" Longitude="142.63972222" Speed="430" Altitude="33000" />
             <Cleared Level="9000" />
             <FlightPlan Active="true" Departure="YPAD" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="440" ETD="0001" ATD="0001" RFL="35000" EETHours="00" EETMins="10" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO Y12 ARBEY ARBE7A/16</FlightPlan>
-            <Route>APPLE ARBEY BELTA</Route>
+            <Route>APPLE ARBEY RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="TGG820" Type="A320" Delay="0">
             <Squawk Code="4112" ModeC="true" />
             <Position Latitude="-36.51083333" Longitude="147.39500000" Speed="410" Altitude="38000" />
             <Cleared Level="9000" />
             <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="410" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TESAT H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-            <Route>NABBA BULLA LIZZI HORUS NEFER BELTA</Route>
+            <Route>NABBA BULLA LIZZI RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="QFA699" Type="B738" Delay="30" StartAuto="true">
             <Squawk Code="3001" ModeC="true" />
             <Position Latitude="-36.22722222" Longitude="142.26583333" Speed="430" Altitude="35000" />
             <Cleared Level="9000" />
             <FlightPlan Active="true" Departure="YPAD" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="440" ETD="0001" ATD="0001" RFL="35000" EETHours="00" EETMins="10" FuelHours="0" FuelMins="0" Remarks="/v/">BENDO Y12 ARBEY ARBE7A/16</FlightPlan>
-            <Route>KEPPA APPLE ARBEY BELTA</Route>
+            <Route>KEPPA APPLE ARBEY RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ1755" Type="B738" Delay="0">
             <Squawk Code="4337" ModeC="true" />
             <Position Latitude="-40.356549" Longitude="146.565559" Speed="420" Altitude="36000" />
             <Cleared Level="9000" />
             <FlightPlan Active="true" Departure="YMHB" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">KANLI H111 LT H215 WAREN WARE8A/16</FlightPlan>
-            <Route>FLIKI WAREN MICHM MONTY SANDR LAGUG NEFER BELTA</Route>
+            <Route>FLIKI WAREN RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="JST811" Type="A320" Delay="0">
             <Squawk Code="4115" ModeC="true" />
             <Position Latitude="-36.004223" Longitude="148.301395" Speed="410" Altitude="38000" />
             <Cleared Level="9000" />
             <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="410" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT TESAT H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-            <Route>RUMIE NABBA BULLA LIZZI HORUS NEFER BELTA</Route>
+            <Route>RUMIE NABBA BULLA LIZZI RWY16</Route>
           </Aircraft>
           <Aircraft Callsign="YMF7000" Type="F100" Delay="240" StartAuto="true">
             <Squawk Code="3002" ModeC="true" />
             <Position Latitude="-35.44027778" Longitude="146.03527778" Speed="430" Altitude="30000" />
             <Cleared Level="9000" />
             <FlightPlan Active="true" Departure="YBBN" Destination="YMAV" Alternative="" Rules="1" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="30000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">PKS Q35 CANTY JAYBI5/18</FlightPlan>
-            <Route>CANTY SOAPY JAYBI LLOYD</Route>
+            <Route>CANTY SOAPY JAYBI RWY18</Route>
           </Aircraft>
           <Aircraft Callsign="JST626" Type="A320" Delay="0">
             <Squawk Code="2000" ModeC="false" />
@@ -2381,14 +2382,14 @@
             <Position Latitude="-37.662288" Longitude="144.848483" Speed="1" Altitude="397" />
             <Cleared Level="5000" />
             <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="1" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DOSEL1/27 DOSEL Y59 TESAT DCT</FlightPlan>
-            <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY</Route>
+            <Route>DOSEL EBONY</Route>
           </Aircraft>
           <Aircraft Callsign="LRX" Type="LJ35" Delay="0">
             <Squawk Code="3215" ModeC="true" />
             <Position Latitude="-37.662335" Longitude="144.848475" Speed="0" Altitude="397" />
             <Cleared Level="5000" />
             <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="1" CruiseSpeed="220" ETD="0000" ATD="0000" RFL="41000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DOSEL1/27 DOSEL Y59 TESAT DCT</FlightPlan>
-            <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY RIVET TESAT YSSY</Route>
+            <Route>DOSEL EBONY RIVET TESAT YSSY</Route>
             <TimedMessages>
               <TimedMessage Time="1380" Message="Takeoff" />
             </TimedMessages>
@@ -2408,7 +2409,7 @@
             <Position Latitude="-37.66232" Longitude="144.84848" Speed="0" Altitude="397" />
             <Cleared Level="5000" />
             <FlightPlan Active="true" Departure="YMML" Destination="NZCH" Alternative="" Rules="1" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="35000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">CORRS9/27 CORRS Y66 LEPAR</FlightPlan>
-            <Route>HOPLA DARLY STEVO CORRS LEPAR</Route>
+            <Route>CORRS LEPAR</Route>
             <TimedMessages>
               <TimedMessage Time="420" Message="Takeoff." />
             </TimedMessages>
@@ -2418,7 +2419,7 @@
             <Position Latitude="-37.662351" Longitude="144.848471" Speed="0" Altitude="397" />
             <Cleared Level="5000" />
             <FlightPlan Active="true" Departure="YMML" Destination="YPAD" Alternative="" Rules="1" CruiseSpeed="420" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">NEVIS7/27 NEVIS H345 DRINA DCT</FlightPlan>
-            <Route>ATNOL NEVIS BORTO</Route>
+            <Route>NEVIS BORTO</Route>
             <TimedMessages>
               <TimedMessage Time="840" Message="Takeoff" />
             </TimedMessages>
@@ -2490,49 +2491,49 @@
           <Cleared Level="9000" />
           <Position Latitude="-37.78" Longitude="141.375" Speed="450" Altitude="37000" />
           <FlightPlan Active="true" Departure="YPPH" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="37000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2 /v/">DCT MEMUP Y53 WENDY WEND1A/34</FlightPlan>
-          <Route>TYNDI WENDY NIXEN TEENA MEMEG LAVER OBGAL AKDEL RWY34</Route>
+          <Route>TYNDI WENDY RWY34</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ1030" Type="B738" Delay="0">
           <Squawk Code="1340" ModeC="true" />
           <Cleared Level="9000" />
           <Position Latitude="-37.025166" Longitude="144.698333" Speed="250" Altitude="13000" />
           <FlightPlan Active="true" Departure="YBSU" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2 /v/">DCT SU Q35 CANTY H119 ARBEY ARBE7A/34</FlightPlan>
-          <Route>ARBEY TUNKA BELTA OVNER RENER GOSKO OBGAL AKDEL BOGSI MMLSM RWY34</Route>
+          <Route>ARBEY RWY34</Route>
         </Aircraft>
         <Aircraft Callsign="QFA405" Type="B738" Delay="0">
           <Squawk Code="2742" ModeC="true" />
           <Cleared Level="9000" />
           <Position Latitude="-37.19" Longitude="146.14" Speed="350" Altitude="18000" />
           <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2 /v/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9V/34V</FlightPlan>
-          <Route>TAREX LIZZI MAITE IGPON MONTY EGEKA SHEED RWY34</Route>
+          <Route>LUVAS LIZZI ATPER MAITE IGPON MONTY EGEKA SHEED HORSH RWY34</Route>
         </Aircraft>
         <Aircraft Callsign="TFX15" Type="AT43" Delay="0">
           <Squawk Code="2611" ModeC="true" />
           <Cleared Level="9000" />
           <Position Latitude="-36.86" Longitude="146.54" Speed="250" Altitude="16000" />
           <FlightPlan Active="true" Departure="YSBK" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="241" ETD="0000" ATD="0000" RFL="16000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/B NAV/RNP2 /v/">DCT BK DCT PEGSU V169 BOYSE BOYS8V/34V</FlightPlan>
-          <Route>TEMIS BOYSE MAXAL ARTHA EMRIG MONTY EGEKA SHEED RWY34</Route>
+          <Route>TEMIS BOYSE MAXAL ARTHA EMRIG MONTY EGEKA SHEED HORSH RWY34</Route>
         </Aircraft>
         <Aircraft Callsign="QLK205" Type="DH8C" Delay="0">
           <Squawk Code="2511" ModeC="true" />
           <Cleared Level="9000" />
           <Position Latitude="-39.04" Longitude="145.785" Speed="300" Altitude="22000" />
           <FlightPlan Active="true" Departure="YDPO" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="277" ETD="0000" ATD="0000" RFL="22000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/B NAV/RNP2 /v/">DCT IRSOM V246 ONAGI H215 WAREN WARE8V/34V</FlightPlan>
-          <Route>ONAGI WAREN MICHM MONTY EGEKA SHEED RWY34</Route>
+          <Route>ONAGI WAREN MICHM MONTY EGEKA SHEED HORSH RWY34</Route>
         </Aircraft>
         <Aircraft Callsign="CPA3710" Type="B748" Delay="0">
           <Squawk Code="2411" ModeC="true" />
           <Cleared Level="9000" />
           <Position Latitude="-35.035" Longitude="150.0" Speed="480" Altitude="43000" />
           <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="489" ETD="0000" ATD="0000" RFL="43000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/D NAV/RNP2 /v/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/34</FlightPlan>
-          <Route>TANTA RUMIE NABBA BULLA TAREX LIZZI VEPUD AKSID GOOLA BOLTY AKDEL BOGSI MMLSM</Route>
+          <Route>TANTA RUMIE NABBA BULLA LUVAS LIZZI RWY34</Route>
         </Aircraft>
         <Aircraft Callsign="JST513" Type="A320" Delay="0">
           <Squawk Code="2746" ModeC="true" />
           <Cleared Level="9000" />
           <Position Latitude="-35.88" Longitude="148.565" Speed="450" Altitude="38000" />
           <FlightPlan Active="true" Departure="YSSY" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2 /v/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9V/34V</FlightPlan>
-          <Route>NABBA BULLA TAREX LIZZI MAITE IGPON MONTY EGEKA SHEED RWY34</Route>
+          <Route>NABBA BULLA LUVAS LIZZI ATPER MAITE IGPON MONTY EGEKA SHEED HORSH RWY34</Route>
         </Aircraft>
         <Aircraft Callsign="ETS" Type="BE58" Delay="0">
           <Squawk Code="3020" ModeC="true" />
@@ -2554,56 +2555,59 @@
           <FlightPlan Active="true" Departure="YNHL" Destination="YMML" Alternative="" Rules="1" CruiseSpeed="270" ETD="0000" ATD="0000" RFL="9000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/B NAV/RNP2/v/">DCT IRVAK DCT ML DCT</FlightPlan>
           <Route>IRVAK ML</Route>
         </Aircraft>
-        <Aircraft Callsign="QFA35" Type="A333" Delay="120">
+        <Aircraft Callsign="QFA35" Type="A333" Delay="120" StartAuto="true">
           <Squawk Code="3122" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-37.68429299999999" Longitude="144.840701" Speed="1" Altitude="312" />
           <FlightPlan Active="true" Departure="YMML" Destination="WSSS" Alternative="" Rules="1" CruiseSpeed="473" ETD="0000" ATD="0000" RFL="32000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/D NAV/RNP2/v/">KEPPA2/34 KEPPA Q168 WR/M082F340 T29 AYE/M082F360 T29 CIN A576 ATMAP M635 UDONO/M081F380 M635 SURGA DCT</FlightPlan>
-          <Route>OKMEL KEPPA</Route>
+          <Route>KEPPA BOLAM</Route>
         </Aircraft>
-        <Aircraft Callsign="ANZ124" Type="B788" Delay="1140">
+        <Aircraft Callsign="ANZ124" Type="B788" Delay="1140" StartAuto="true">
           <Squawk Code="4213" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-37.68429299999999" Longitude="144.840701" Speed="1" Altitude="312" />
           <FlightPlan Active="true" Departure="YMML" Destination="NZAA" Alternative="" Rules="1" CruiseSpeed="478" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/D NAV/RNP2/v/">CORRS9/34 CORRS Y81 GEMAC/M085F390 DCT 38S163E DCT LUNBI DCT AA DCT </FlightPlan>
-          <Route>ROKDL POREM GEDEN CORRS GEMAC</Route>
+          <Route>CORRS GEMAC</Route>
         </Aircraft>
-        <Aircraft Callsign="JST510" Type="A320" Delay="1320">
+        <Aircraft Callsign="JST510" Type="A320" Delay="1320" StartAuto="true">
           <Squawk Code="4103" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-37.68429299999999" Longitude="144.840701" Speed="1" Altitude="312" />
           <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="1" CruiseSpeed="451" ETD="0000" ATD="0000" RFL="35000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2/v/">DOSEL1/34 DOSEL Y59 TESAT DCT</FlightPlan>
-          <Route>ROKDL SALLY DOSEL EBONY</Route>
+          <Route>DOSEL EBONY</Route>
         </Aircraft>
-        <Aircraft Callsign="QFA610" Type="B738" Delay="480">
+        <Aircraft Callsign="QFA610" Type="B738" Delay="480" StartAuto="true">
           <Squawk Code="3470" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-37.68429299999999" Longitude="144.840701" Speed="1" Altitude="312" />
           <FlightPlan Active="true" Departure="YMML" Destination="YBCG" Alternative="" Rules="1" CruiseSpeed="457" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2/v/">NONIX3/34 NONIX H66 BLAKA DCT</FlightPlan>
-          <Route>ROKDL SALLY NONIX</Route>
+          <Route>NONIX</Route>
         </Aircraft>
-        <Aircraft Callsign="VOZ219" Type="B738" Delay="1800">
+        <Aircraft Callsign="VOZ219" Type="B738" Delay="1800" StartAuto="true">
           <Squawk Code="4360" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-37.68429299999999" Longitude="144.840701" Speed="1" Altitude="312" />
           <FlightPlan Active="true" Departure="YMML" Destination="YPAD" Alternative="" Rules="1" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="40000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2/v/">NEVIS7/34 NEVIS H345 DRINA DCT</FlightPlan>
-          <Route>OKMEL NEVIS</Route>
+          <Route>NEVIS</Route>
         </Aircraft>
-        <Aircraft Callsign="QLK227" Type="DH8C" Delay="660">
+        <Aircraft Callsign="QLK227" Type="DH8C" Delay="660" StartAuto="true">
           <Squawk Code="4330" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-37.68429299999999" Longitude="144.840701" Speed="0" Altitude="312" />
-          <FlightPlan Active="true" Departure="YMML" Destination="YMLT" Alternative="" Rules="1" CruiseSpeed="304" ETD="0000" ATD="0000" RFL="23000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2/v/">ML6/34 ML H169 IRSOM W105 LT DCT</FlightPlan>
-          <Route>SUNTI BENZO</Route>
+          <FlightPlan Active="true" Departure="YMML" Destination="YMLT" Alternative="" Rules="1" CruiseSpeed="304" ETD="0000" ATD="0000" RFL="23000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2/v/">ML6/34 SUNTI H169 IRSOM W105 LT DCT</FlightPlan>
+          <Route>SUNTI AVNAS</Route>
+          <TimedMessages>
+            <TimedMessage Time="0" Message="Add SUNTI to route before AVNAS" />
+          </TimedMessages>
         </Aircraft>
-        <Aircraft Callsign="JST900" Type="A320" Delay="1620">
+        <Aircraft Callsign="JST900" Type="A320" Delay="1620" StartAuto="true">
           <Squawk Code="3101" ModeC="true" />
           <Cleared Level="5000" />
           <Position Latitude="-37.68429299999999" Longitude="144.840701" Speed="1" Altitude="312" />
           <FlightPlan Active="true" Departure="YMML" Destination="YBLN" Alternative="" Rules="1" CruiseSpeed="454" ETD="0000" ATD="0000" RFL="36000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PER/C NAV/RNP2/v/">CRENA1/34 CRENA Q158 COBEL DCT HOODY DCT BLN DCT</FlightPlan>
-          <Route>MMLSH HOPLA CRENA</Route>
+          <Route>CRENA</Route>
         </Aircraft>
-        <Aircraft Callsign="YUP" Type="C182" Delay="240">
+        <Aircraft Callsign="YUP" Type="C182" Delay="240" StartAuto="true">
           <Squawk Code="3105" ModeC="true" />
           <Cleared Level="4000" />
           <Position Latitude="-37.68429299999999" Longitude="144.840701" Speed="0" Altitude="312" />
@@ -2679,14 +2683,14 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="1" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="370" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">DOSEL1/27 DOSEL Y59 RIVET DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ875" Type="B738" Delay="0" StartAuto="false">
           <Squawk Code="2435" ModeC="true" />
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="370" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">DOSEL1/27 DOSEL Y59 RIVET DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           <TimedMessages>
             <TimedMessage Time="100" Message="Takeoff" />
           </TimedMessages>
@@ -2696,7 +2700,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="350" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVFX OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DOSEL1/27 DOSEL Y59 RIVET DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           <TimedMessages>
             <TimedMessage Time="200" Message="Takeoff" />
           </TimedMessages>
@@ -2706,7 +2710,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="370" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/ ">DOSEL1/27 DOSEL Y59 RIVET DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           <TimedMessages>
             <TimedMessage Time="300" Message="Takeoff" />
           </TimedMessages>
@@ -2716,7 +2720,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="370" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/ ">DOSEL1/27 DOSEL Y59 RIVET DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           <TimedMessages>
             <TimedMessage Time="400" Message="Takeoff" />
           </TimedMessages>
@@ -2726,7 +2730,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="330" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVWU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DOSEL1/27 DOSEL Y59 RIVET DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           <TimedMessages>
             <TimedMessage Time="500" Message="Takeoff" />
           </TimedMessages>
@@ -2747,7 +2751,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSSY" Alternative="" Active="true" Equipment="SDFGHRY/LB1" Rules="I" CruiseSpeed="398" ETD="0000" ATD="0000" RFL="290" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/B2C2D2O2 DOF/240101 REG/VHSAZ CODE/7C5B39 OPR/EXP FREIGHT AUST ORGN/YSSYQFAO /V/">DOSEL1/27 DOSEL Y59 RIVET DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           <TimedMessages>
             <TimedMessage Time="600" Message="Takeoff" />
             <TimedMessage Time="800" Message="Set Speed to 250/0.6" />
@@ -2758,7 +2762,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="390" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 RNVD1A1 SUR/260B DOF/240101 REG/VHEBO EET/YBBB0103 SEL/CEFS CODE/7C5325 OPR/QFA ORGN/YSSYQFAO PER/C /V/">DOSEL1/27 DOSEL Y59 RIVET DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           <TimedMessages>
             <TimedMessage Time="700" Message="Takeoff" />
           </TimedMessages>
@@ -2768,7 +2772,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="370" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHVWU OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DOSEL1/27 DOSEL Y59 RIVET DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           <TimedMessages>
             <TimedMessage Time="1000" Message="Takeoff" />
           </TimedMessages>
@@ -2778,7 +2782,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSSY" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="370" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/ ">DOSEL1/27 DOSEL Y59 RIVET DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           <TimedMessages>
             <TimedMessage Time="1400" Message="Takeoff" />
           </TimedMessages>
@@ -2788,7 +2792,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YBSU" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="370" EETHours="1" EETMins="15" FuelHours="2" FuelMins="20" Remarks="PBN/A1L1O1S1 NAV/RNP2 DOF/240101 REG/VHUJT EET/YBBB0051 SEL/HPMS CODE/7C6697 OPR/BNZ PER/C /V/ ">NONIX3/27 NONIX H66 IDNER W214 GOMOL Q69 ITIDE DCT </FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART NONIX KACEY MUDGI</Route>
+          <Route>NONIX KACEY MUDGI</Route>
           <TimedMessages>
             <TimedMessage Time="1700" Message="Takeoff" />
           </TimedMessages>
@@ -2798,7 +2802,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YSCB" Alternative="" Active="true" Equipment="SDFGIRWZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="310" EETHours="0" EETMins="55" FuelHours="1" FuelMins="50" Remarks="PBN/L1O2S1 NAV/RNP2 COM/IRIDIUM881651484931 DOF/240101 REG/VHYQS EET/YBBB0056 CODE/7C7BD2 OPR/NATIONAL JET SYSTEMS PER/C /V/ ">DOSEL1/27 DOSEL Y59 ARRAN DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN CB</Route>
+          <Route>DOSEL EBONY ARRAN CB</Route>
           <TimedMessages>
             <TimedMessage Time="2000" Message="Takeoff" />
           </TimedMessages>
@@ -2808,7 +2812,7 @@
           <Cleared Level="5000" Approach="false" />
           <Position Latitude="-37.66219179941475" Longitude="144.84774499038323" Speed="0" Altitude="407" />
           <FlightPlan Departure="YMML" Destination="YWLM" Alternative="" Active="true" Equipment="SDGHIRWYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="350" EETHours="01" EETMins="30" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/230117 REG/VHUZK EET/YBBB0108 SEL/EQHK CODE/7C68CE OPR/ALLIANCE ORGN/YSSYQFAO PER/C /V/ ">DOSEL1/27 DOSEL Y59 TESAT H252 EKIPU DCT</FlightPlan>
-          <Route>ATNOL PARSI PEBTO PEART DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET TESAT OLSEM UPNEX EKIPU WLM</Route>
+          <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET TESAT OLSEM UPNEX EKIPU WLM</Route>
           <TimedMessages>
             <TimedMessage Time="2100" Message="Takeoff" />
           </TimedMessages>
@@ -2819,77 +2823,77 @@
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-37.361944" Longitude="145.805278" Speed="300" Altitude="17000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ874" Type="B738" Delay="0" StartAuto="false">
           <Squawk Code="1213" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-37.079167" Longitude="146.351667" Speed="400" Altitude="26000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>LUVAS LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="JST531" Type="A21N" Delay="0" StartAuto="false">
           <Squawk Code="3227" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.846944" Longitude="146.781667" Speed="410" Altitude="31000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHOFE OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>BULLA LUVAS LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="CPA3122" Type="B748" Delay="0" StartAuto="false">
           <Squawk Code="3114" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.608611" Longitude="147.214444" Speed="480" Altitude="36000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1L1O1S2T1 NAV/RNP2 COM/INTEGRATED DAT/1FANSER2PDC SUR/260B RSP180 DOF/240101 REG/BLJK EET/YMMM0050 SEL/CKDH CODE/780A6E OPR/CPA ORGN/EDDFCPAX PER/D RMK/CARGO AIRCRAFT /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>NABBA BULLA LUVAS LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="RXA161" Type="B738" Delay="0" StartAuto="false">
           <Squawk Code="3765" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.556667" Longitude="147.3225" Speed="450" Altitude="38000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1L1O1S2 NAV/RNP2 DOF/240101 REG/VHRQP SEL/CEDQ CODE/7C585F OPR/RXA ORGN/KAUSFFLX PER/C /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>NABBA BULLA LUVAS LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ886" Type="B38M" Delay="0" StartAuto="false">
           <Squawk Code="6732" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.379167" Longitude="147.633056" Speed="450" Altitude="38000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>NABBA BULLA LUVAS LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="TFX22" Type="B734" Delay="0" StartAuto="false">
           <Squawk Code="0127" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.240833" Longitude="147.891944" Speed="440" Altitude="34000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDFGHIM3RWZ/LB1" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="340" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O2S2 NAV/RNP2 DOF/240101 REG/ZKTLJ SEL/EPCR CODE/C822C4 OPR/TFX PER/C RMK/TCAS EQUIPPED /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>RUMIE NABBA BULLA LUVAS LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>RUMIE NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="TAA406" Type="A306" Delay="0" StartAuto="false">
           <Squawk Code="5552" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.051667" Longitude="148.237778" Speed="470" Altitude="40000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="400" EETHours="1" EETMins="20" FuelHours="2" FuelMins="15" Remarks="PBN/A1B1D1O1S1S2 NAV/RNP2 DOF/240112 REG/VHTAE SEL/DGCF CODE/8961D3 OPR/TAA PER/C /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>RUMIE NABBA BULLA LUVAS LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>RUMIE NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ888" Type="B738" Delay="0" StartAuto="false">
           <Squawk Code="2365" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-35.981667" Longitude="148.351944" Speed="450" Altitude="36000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHYUD OPR/VOZ PER/C RMK/TCAS /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>RUMIE NABBA BULLA LUVAS LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>RUMIE NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="QFA485" Type="B738" Delay="0" StartAuto="false">
           <Squawk Code="6564" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-35.684722" Longitude="148.869722" Speed="450" Altitude="38000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="380" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VHVZG SEL/ESAM CODE/7C6DDA OPR/QANTAS ORGN/YSSYQFAO PER/C /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>RUMIE NABBA BULLA LUVAS LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>RUMIE NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="8AX" Type="C700" Delay="0" StartAuto="false">
           <Squawk Code="7104" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-35.335556" Longitude="149.480833" Speed="450" Altitude="43000" />
           <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="430" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S1S2T1 NAV/RNP2 DOF/240101 REG/VH8AX SEL/ESAM CODE/7C6DDA OPR/JETSTREAM AVIATION PER/C /V/">DCT WOL H65 RAZZI Q29 LIZZI LIZI9A/16</FlightPlan>
-          <Route>RUMIE NABBA BULLA LUVAS LIZZI MAXAL HORUS ENSEG NEFER BELTA RWY16</Route>
+          <Route>RUMIE NABBA BULLA LUVAS LIZZI RWY16</Route>
         </Aircraft>
     // Off Route Arrivals
         <Aircraft Callsign="QLK47" Type="DH8C" Delay="0" StartAuto="true">
@@ -2897,7 +2901,7 @@
           <Cleared Level="14000" Approach="false" />
           <Position Latitude="-36.06796985482588" Longitude="146.9494271163329" Speed="1" Altitude="531" />
           <FlightPlan Departure="YMAY" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="254" ETD="0000" ATD="0000" RFL="140" EETHours="0" EETMins="45" FuelHours="1" FuelMins="30" Remarks="PBN/A1S1 NAV/RNP2 DOF/240101 REG/VHTQL OPR/QANTASLINK ORGN/YSSYQFAO PER/B /V/">DUGGI1/07 DUGGI V147 TEMIS V169 BOYSE BOYS8A/16</FlightPlan>
-          <Route>ANUGO RUMES DUGGI TEMIS BOYSE VALES ANBEL BUVIV NEFER BELTA RWY16</Route>
+          <Route>ANUGO RUMES DUGGI TEMIS BOYSE RWY16</Route>
           <TimedMessages>
             <TimedMessage Time="1200" Message="Set CFL to A090" />
           </TimedMessages>
@@ -2907,14 +2911,14 @@
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-39.716944" Longitude="146.240556" Speed="435" Altitude="36000" />
           <FlightPlan Departure="YMLT" Destination="YMML" Alternative="" Active="true" Equipment="SBDE2E3GHIJ2J3J4J7LM3OP2RVWXYZ/LB1D1" Rules="I" CruiseSpeed="435" ETD="0000" ATD="0000" RFL="360" EETHours="0" EETMins="55" FuelHours="1" FuelMins="55" Remarks="PBN/A1B1C1D1L1O2S2 NAV/RNP2 COM/IRIDIUM8816600241103 SUR/260B RSP180 DOF/240101 REG/VHX4A SEL/LMFR CODE/7C78A8 OPR/NATIONAL JET SYSTEMS ORGN/YSSYQFAO PER/C /V/">DCT EXROM DCT WAREN WARE8A/16</FlightPlan>
-          <Route>EXROM WAREN MICHM MONTY SANDR LAGUG NEFER BELTA RWY16</Route>
+          <Route>EXROM WAREN RWY16</Route>
         </Aircraft>
         <Aircraft Callsign="RXA466" Type="B738" Delay="0" StartAuto="false">
           <Squawk Code="3614" ModeC="true" />
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-35.471944" Longitude="140.111667" Speed="450" Altitude="37000" />
           <FlightPlan Departure="YPAD" Destination="YMML" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="370" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1L1O1S2 NAV/RNP2 DOF/240101 REG/VHRQP SEL/CEDQ CODE/7C585F OPR/RXA ORGN/KAUSFFLX PER/C /V/">DCT BENDO Y12 ARBEY ARBE7A/16</FlightPlan>
-          <Route>RELEP LULTO APPLE ARBEY TUNKA LASOL BELTA RWY16</Route>
+          <Route>RELEP LULTO APPLE ARBEY RWY16</Route>
         </Aircraft>
     // Other
         <Aircraft Callsign="JST611" Type="A320" Delay="0" StartAuto="false">
@@ -2922,7 +2926,7 @@
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-35.789722" Longitude="148.703611" Speed="450" Altitude="36000" />
           <FlightPlan Departure="YSSY" Destination="YMAV" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="360" EETHours="1" EETMins="25" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/VHOFE OPR/JST PER/C RMK/TCAS EQUIPPED /V/ ">DCT WOL H65 RAZZI Q29 ML JAYBI5/18</FlightPlan>
-          <Route>RUMIE NABBA BULLA LUVAS LIZZI ML JAYBI BEKKA TEMPL RWY18</Route>
+          <Route>RUMIE NABBA BULLA LUVAS LIZZI ML JAYBI RWY18</Route>
           <TimedMessages>
             <TimedMessage Time="1140" Message="If there is less than 7nm separation with VOZ888, apply vertical separation (1000ft above VOZ888's last vacated level). Handoff when ready to MAE with vertical separation in place" />
           </TimedMessages>
@@ -2932,7 +2936,7 @@
           <Cleared Level="9000" Approach="false" />
           <Position Latitude="-36.091944" Longitude="141.8625" Speed="450" Altitude="33000" />
           <FlightPlan Departure="YPAD" Destination="YMAV" Alternative="" Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1U1" Rules="I" CruiseSpeed="449" ETD="0000" ATD="0000" RFL="330" EETHours="1" EETMins="05" FuelHours="2" FuelMins="00" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/240101 REG/A47001 OPR/RAAF PER/C RMK/TCAS EQUIPPED /V/ ">DCT BENDO Y12 APPLE JAYBI5/18</FlightPlan>
-          <Route>RELEP LULTO APPLE SOAPY JAYBI BEKKA TEMPL RWY18</Route>
+          <Route>RELEP LULTO APPLE SOAPY JAYBI RWY18</Route>
         </Aircraft>
         <Aircraft Callsign="BSV" Type="C172" Delay="0" StartAuto="false">
           <Squawk Code="1200" ModeC="true" />
@@ -2980,14 +2984,14 @@
           <Cleared Level="10000" />
           <Position Latitude="-34.82143800000001" Longitude="149.25946800000003" Speed="460" Altitude="22000" />
           <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>TARAL RIVET BOOGI DUDOK NASHO</Route>
+          <Route>TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="SIA221" Type="A332" Delay="0">
           <Squawk Code="4157" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-33.866524" Longitude="148.85513" Speed="460" Altitude="25000" />
           <FlightPlan Active="true" Departure="WSSS" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="480" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TI A576 SIPUT W13 BLI A576 PKS MAKKA TARAL Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>MAKKA TARAL RIVET BOOGI DUDOK NASHO</Route>
+          <Route>MAKKA TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="WFE" Type="BE58" Delay="0">
           <Squawk Code="1200" ModeC="false" />
@@ -3000,21 +3004,21 @@
           <Cleared Level="10000" />
           <Position Latitude="-34.69548799999999" Longitude="149.492329" Speed="435" Altitude="22000" />
           <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="REG/VHVHF PER/C OPR/VIRGIN AUSTRALIA NAV/RNP10 GPSRNAV RMK/TCAS EQUIPPED     /v/">DCT DOSEL Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>TARAL RIVET TAMMI BOOGI DUDOK NASHO</Route>
+          <Route>TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="JST763" Type="A321" Delay="0">
           <Squawk Code="4122" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-34.583427" Longitude="149.756614" Speed="435" Altitude="20000" />
           <FlightPlan Active="true" Departure="YPAD" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="REG/VHJST  PER/D NAV/RNP2 OPR/JETSTAR     /v/">AVDEN H247 CULIN Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>TARAL RIVET BIGEM TAMMI BOOGI DUDOK NASHO</Route>
+          <Route>TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="QFA509" Type="B738" Delay="0">
           <Squawk Code="3265" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-32.536238" Longitude="150.9128" Speed="435" Altitude="20000" />
           <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="480" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="15" FuelHours="0" FuelMins="0" Remarks="REG/VHQFA PER/B     /v/">DCT SANEG H91 IGDAM H12 BOREE BORE3A/34R</FlightPlan>
-          <Route>BOREE BEROW OVILS MAJAR JAKLN</Route>
+          <Route>BOREE RWY34R</Route>
         </Aircraft>
         <Aircraft Callsign="GR516" Type="B738" Delay="0">
           <Squawk Code="3177" ModeC="true" />
@@ -3028,21 +3032,21 @@
           <Cleared Level="10000" />
           <Position Latitude="-35.091704" Longitude="149.285583" Speed="420" Altitude="25000" />
           <FlightPlan Active="true" Departure="YSCB" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="448" ETD="0010" ATD="0010" RFL="10000" EETHours="00" EETMins="50" FuelHours="0" FuelMins="0" Remarks="REG/VHCNT     /v/">DCT CB W423 CULIN Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>CULIN TARAL RIVET TAMMI BOOGI DUDOK NASHO</Route>
+          <Route>CULIN TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="JST795" Type="A321" Delay="0">
           <Squawk Code="3254" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-35.275169000000005" Longitude="148.559008" Speed="451" Altitude="30000" />
           <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="445" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>CULIN TARAL RIVET TAMMI BOOGI DUDOK NASHO</Route>
+          <Route>CULIN TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="QFA501" Type="B744" Delay="0">
           <Squawk Code="3361" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-35.524636" Longitude="148.104383" Speed="488" Altitude="30000" />
           <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="10" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>CULIN TARAL RIVET TAMMI BOOGI DUDOK NASHO</Route>
+          <Route>CULIN TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="REW" Type="C182" Delay="0">
           <Squawk Code="1200" ModeC="true" />
@@ -3062,7 +3066,7 @@
           <Cleared Level="10000" />
           <Position Latitude="-34.06428" Longitude="152.36233899999996" Speed="350" Altitude="18000" />
           <FlightPlan Active="true" Departure="NZAA" Destination="YSSY" Alternative="YSCB" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="10000" EETHours="03" EETMins="50" FuelHours="0" FuelMins="0" Remarks="REG/ZKANZ PER/C RMK/KIWI     /v/">DCT MADEP N774 OLREL/M080F360 N774 MARLN MARLN5/34R</FlightPlan>
-          <Route>MARLN PRAWN JAKLN</Route>
+          <Route>MARLN RWY34R</Route>
         </Aircraft>
         <Aircraft Callsign="UAL15" Type="B789" Delay="0">
           <Squawk Code="4212" ModeC="true" />
@@ -3119,6 +3123,9 @@
           <Position Latitude="-33.963778" Longitude="151.180626" Speed="0" Altitude="7" />
           <FlightPlan Active="true" Departure="YSSY" Destination="YBTH" Alternative="" Rules="I" CruiseSpeed="240" ETD="0000" ATD="0000" RFL="16000" EETHours="01" EETMins="10" FuelHours="0" FuelMins="0" Remarks="/v/">SY3/34L KADOM W386 BTH DCT</FlightPlan>
           <Route>KADOM BTH YBTH</Route>
+          <TimedMessages>
+            <TimedMessage Time="0" Message="Add KADOM to route before BTH" />
+          </TimedMessages>
         </Aircraft>
         <Aircraft Callsign="JST760" Type="A320" Delay="0">
           <Squawk Code="2313" ModeC="true" />
@@ -3165,7 +3172,7 @@
           <Cleared Level="10000" />
           <Position Latitude="-33.866524" Longitude="148.85513" Speed="460" Altitude="25000" />
           <FlightPlan Active="true" Departure="WSSS" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="480" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">TI A576 SIPUT W13 BLI A576 PKS MAKKA TARAL Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>MAKKA TARAL RIVET BOOGI DUDOK NASHO</Route>
+          <Route>MAKKA TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="WFE" Type="BE58" Delay="0">
           <Squawk Code="1200" ModeC="false" />
@@ -3178,49 +3185,49 @@
           <Cleared Level="10000" />
           <Position Latitude="-34.69548799999999" Longitude="149.492329" Speed="435" Altitude="22000" />
           <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="REG/VHVHF PER/C OPR/VIRGIN AUSTRALIA NAV/RNP10 GPSRNAV RMK/TCAS EQUIPPED     /v/">DCT DOSEL Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>TARAL RIVET TAMMI BOOGI DUDOK NASHO</Route>
+          <Route>TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="JST763" Type="A321" Delay="0">
           <Squawk Code="4122" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-34.583427" Longitude="149.756614" Speed="435" Altitude="20000" />
           <FlightPlan Active="true" Departure="YPAD" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="10000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="REG/VHJST  PER/D NAV/RNP2 OPR/JETSTAR     /v/">AVDEN H247 CULIN Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>TARAL RIVET BIGEM TAMMI BOOGI DUDOK NASHO</Route>
+          <Route>TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="QFA509" Type="B738" Delay="0">
           <Squawk Code="3265" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-32.64138889" Longitude="150.93694444" Speed="435" Altitude="20000" />
           <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="480" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="15" FuelHours="0" FuelMins="0" Remarks="REG/VHQFA PER/B     /v/">DCT SANEG H91 IGDAM H12 BOREE BORE3A/34R</FlightPlan>
-          <Route>BOREE BEROW OVILS MAJAR JAKLN</Route>
+          <Route>BOREE RWY34R</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ1549" Type="B738" Delay="0">
           <Squawk Code="3177" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-32.969718" Longitude="150.99906099999998" Speed="435" Altitude="18000" />
           <FlightPlan Active="true" Departure="YCFS" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="18" FuelHours="0" FuelMins="0" Remarks="REG/VHCFS PER/C     /v/">CFS J70 IGDAM H12 BOREE BORE3A/34R</FlightPlan>
-          <Route>BOREE BEROW OVILS MAJAR DIPPA JAKLN</Route>
+          <Route>BOREE RWY34R</Route>
         </Aircraft>
         <Aircraft Callsign="EVY701" Type="B737" Delay="0">
           <Squawk Code="3120" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-35.091704" Longitude="149.285583" Speed="420" Altitude="25000" />
           <FlightPlan Active="true" Departure="YSCB" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="448" ETD="0010" ATD="0010" RFL="10000" EETHours="00" EETMins="50" FuelHours="0" FuelMins="0" Remarks="REG/VHCNT     /v/">DCT CB W423 CULIN Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>CULIN TARAL RIVET TAMMI BOOGI DUDOK NASHO</Route>
+          <Route>CULIN TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="JST795" Type="A321" Delay="0">
           <Squawk Code="3254" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-35.275169000000005" Longitude="148.559008" Speed="451" Altitude="30000" />
           <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="445" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="21" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>CULIN TARAL RIVET TAMMI BOOGI DUDOK NASHO</Route>
+          <Route>CULIN TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="QFA501" Type="B744" Delay="0">
           <Squawk Code="3361" ModeC="true" />
           <Cleared Level="10000" />
           <Position Latitude="-35.524636" Longitude="148.104383" Speed="488" Altitude="30000" />
           <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="470" ETD="0000" ATD="0000" RFL="10000" EETHours="01" EETMins="10" FuelHours="0" FuelMins="0" Remarks="/v/">DCT ML H129 DOSEL Y59 RIVET RIVET3/34L</FlightPlan>
-          <Route>CULIN TARAL RIVET TAMMI BOOGI DUDOK NASHO</Route>
+          <Route>CULIN TARAL RIVET RWY34L</Route>
         </Aircraft>
         <Aircraft Callsign="REW" Type="C182" Delay="0">
           <Squawk Code="1200" ModeC="true" />
@@ -3240,7 +3247,7 @@
           <Cleared Level="10000" />
           <Position Latitude="-34.06428" Longitude="152.36233899999996" Speed="350" Altitude="18000" />
           <FlightPlan Active="true" Departure="NZAA" Destination="YSSY" Alternative="YSCB" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="10000" EETHours="03" EETMins="50" FuelHours="0" FuelMins="0" Remarks="REG/ZKANZ PER/C RMK/KIWI     /v/">DCT MADEP N774 OLREL/M080F360 N774 MARLN MARLN5/34R</FlightPlan>
-          <Route>MARLN PRAWN JAKLN</Route>
+          <Route>MARLN RWY34R</Route>
         </Aircraft>
         <Aircraft Callsign="UAL15" Type="B789" Delay="0">
           <Squawk Code="4212" ModeC="true" />
@@ -3296,7 +3303,10 @@
           <Cleared Level="3000" />
           <Position Latitude="-33.963778" Longitude="151.180626" Speed="0" Altitude="7" />
           <FlightPlan Active="true" Departure="YSSY" Destination="YBTH" Alternative="" Rules="I" CruiseSpeed="240" ETD="0000" ATD="0000" RFL="16000" EETHours="01" EETMins="10" FuelHours="0" FuelMins="0" Remarks="/v/">SY3/34L KADOM W386 BTH DCT</FlightPlan>
-          <Route>KADOM YBTH</Route>
+          <Route>KADOM BTH YBTH</Route>
+          <TimedMessages>
+            <TimedMessage Time="0" Message="Add KADOM to route before BTH" />
+          </TimedMessages>
         </Aircraft>
         <Aircraft Callsign="JST760" Type="A320" Delay="0">
           <Squawk Code="2313" ModeC="true" />
@@ -3338,14 +3348,14 @@
           <Cleared Level="9000" />
           <Position Latitude="-33.88888889" Longitude="149.57805556" Speed="240" Altitude="17000" />
           <FlightPlan Active="true" Departure="YPKS" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="240" ETD="0000" ATD="0000" RFL="17000" EETHours="00" EETMins="55" FuelHours="0" FuelMins="0" Remarks="REG/VHNRX PER/C OPR/REX EXPRESS    /v/">PKS W440 AKMIR W113 ODALE ODALE7/34R</FlightPlan>
-          <Route>AKMIR WELSH ODALE KABLO MITSA ANKUB TESAT</Route>
+          <Route>AKMIR WELSH ODALE RWY34R</Route>
         </Aircraft>
         <Aircraft Callsign="QLK43" Type="DH8C" Delay="0">
           <Squawk Code="4055" ModeC="true" />
           <Cleared Level="9000" />
           <Position Latitude="-33.45277778" Longitude="149.51944444" Speed="260" Altitude="21000" />
           <FlightPlan Active="true" Departure="YSDU" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="260" ETD="0000" ATD="0000" RFL="21000" EETHours="00" EETMins="55" FuelHours="0" FuelMins="0" Remarks="REG/VHSBC PER/C OPR/QANTASLINK    /v/">DU V138 AKMIR W113 ODALE ODALE7/34R</FlightPlan>
-          <Route>AKMIR WELSH ODALE KABLO MITSA ANKUB TESAT</Route>
+          <Route>AKMIR WELSH ODALE RWY34R</Route>
         </Aircraft>
         <Aircraft Callsign="VEF" Type="SF34" Delay="0">
           <Squawk Code="4056" ModeC="true" />
@@ -4109,7 +4119,7 @@
       <Cleared Level="24000" Approach="false" />
       <Position Latitude="-34.958056" Longitude="138.517778" Speed="0" Altitude="33" />
       <FlightPlan Departure="YPAD" Destination="YOLD" Alternative="" Active="true" Equipment="SDGHIRWYZ/LB1" Rules="I" CruiseSpeed="430" ETD="0000" ATD="0000" RFL="320" EETHours="00" EETMins="45" FuelHours="2" FuelMins="20" Remarks="PBN/A1B1C1D1O1S2 NAV/RNP2 DOF/230117 REG/VHUZK EET/YBBB0108 SEL/EQHK CODE/7C68CE OPR/ALLIANCE ORGN/YSSYQFAO PER/C /V/ ">AREPA1/05 AREPA J58 WHA W566 YOLD</FlightPlan>
-      <Route>WAREPA SPOTA WHA POLUP YOLD</Route>
+      <Route>AREPA SPOTA WHA POLUP YOLD</Route>
 	  <TimedMessages>
       <TimedMessage Time="330" Message="Takeoff" />
 		  <TimedMessage Time="650" Message="Set Vertical Speed to 1000ft/min" />
@@ -4556,21 +4566,21 @@
               <Cleared Level="40000" />
               <Position Latitude="-27.374417" Longitude="153.134526" Speed="1" Altitude="3" />
               <FlightPlan Departure="YBBN" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="40000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">SANEG1/19L H91 IGDAM H652 BOREE DCT</FlightPlan>
-              <Route>BOSVU DADAN DENIS LILEE SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM SADLO BOREE</Route>
+              <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM SADLO BOREE</Route>
           </Aircraft>
           <Aircraft Callsign="QFA517" Type="B738" Delay="600" StartAuto="true">
               <Squawk Code="4044" ModeC="true" />
               <Cleared Level="38000" />
               <Position Latitude="-27.374417" Longitude="153.134526" Speed="1" Altitude="3" />
               <FlightPlan Departure="YBBN" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">SANEG1/19L H91 IGDAM H652 BOREE DCT</FlightPlan>
-              <Route>BOSVU DADAN DENIS LILEE SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM SADLO BOREE</Route>
+              <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM SADLO BOREE</Route>
           </Aircraft>
           <Aircraft Callsign="JST529" Type="B738" Delay="300" StartAuto="true">
               <Squawk Code="4045" ModeC="true" />
               <Cleared Level="36000" />
               <Position Latitude="-27.374417" Longitude="153.134526" Speed="1" Altitude="3" />
               <FlightPlan Departure="YBBN" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="36000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1O2S2T1 NAV/RNP2 /v/">SANEG1/19L H91 IGDAM H652 BOREE DCT</FlightPlan>
-              <Route>BOSVU DADAN DENIS LILEE SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM SADLO BOREE</Route>
+              <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM SADLO BOREE</Route>
           </Aircraft>
           <Aircraft Callsign="QFA923" Type="A332" Delay="0">
               <Squawk Code="4037" ModeC="true" />
@@ -4654,28 +4664,28 @@
           <Cleared Level="24000" />
           <Position Latitude="-34.940449" Longitude="138.542794" Speed="1" Altitude="36" />
           <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YPAD" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="33000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/RNP2 REG/VHVXY PER/C /v/">BENDO3/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
-          <Route>COLPY SULLY MORPH CLARY BARKA MURRY BENDO RELEP LULTO APPLE ARBEY</Route>
+          <Route>BENDO RELEP LULTO APPLE ARBEY</Route>
         </Aircraft>
         <Aircraft Callsign="QFA527" Type="B738" Delay="780" StartAuto="true">
           <Squawk Code="2257" ModeC="true" />
           <Cleared Level="24000" />
           <Position Latitude="-34.940449" Longitude="138.542794" Speed="1" Altitude="36" />
           <FlightPlan Departure="YPAD" Destination="YMML" Alternative="YPAD" Active="true" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="33000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/RNP2 REG/VHVXX PER/C /v/">BENDO3/23 BENDO Y12 ARBEY H119 ML</FlightPlan>
-          <Route>COLPY SULLY MORPH CLARY BARKA MURRY BENDO RELEP LULTO APPLE ARBEY</Route>
+          <Route>BENDO RELEP LULTO APPLE ARBEY</Route>
         </Aircraft>
         <Aircraft Callsign="QFA723" Type="B738" Delay="120" StartAuto="true">
           <Squawk Code="4123" ModeC="true" />
           <Cleared Level="24000" />
           <Position Latitude="-34.940456" Longitude="138.542781" Speed="1" Altitude="36" />
           <FlightPlan Departure="YPAD" Destination="YBAS" Alternative="YAYE" Active="true" Rules="I" CruiseSpeed="435" ETD="0000" ATD="0000" RFL="38000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/GPSRNAV PER/C /v/">AREPA1/23 AREPA J58 WHA J251 AS</FlightPlan>
-          <Route>CORNS KEEFO BIGAL AREPA SPOTA WHA OJJAY WR CARTS GOMUL SARAH SADEL AS</Route>
+          <Route>AREPA SPOTA WHA OJJAY WR CARTS GOMUL SARAH SADEL AS</Route>
         </Aircraft>
         <Aircraft Callsign="VOZ455" Type="B738" Delay="1380" StartAuto="true">
           <Squawk Code="2421" ModeC="true" />
           <Cleared Level="24000" />
           <Position Latitude="-34.940438" Longitude="138.542781" Speed="1" Altitude="36" />
           <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="true" Rules="I" CruiseSpeed="460" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="20" FuelHours="0" FuelMins="0" Remarks="NAV/GPSRNAV PER/C /v/">AVDEN1/23 AVDEN H247 CULIN Y59 TESAT</FlightPlan>
-          <Route>COLPY SULLY MORPH CLARY BARKA MURRY AVDEN BOLAM NATYA TOBOB CULIN TARAL RIVET</Route>
+          <Route>AVDEN BOLAM NATYA TOBOB CULIN TARAL RIVET</Route>
         </Aircraft>
         <Aircraft Callsign="MHB" Type="PC12" Delay="600" StartAuto="true">
           <Squawk Code="2574" ModeC="true" />
@@ -5197,10 +5207,10 @@
           <Aircraft Callsign="QLK39D" Type="DH8D" Delay="0">
             <Squawk Code="2000" ModeC="false" />
             <Position Latitude="-36.065455" Longitude="146.96967" Speed="0" Altitude="538" />
-            <FlightPlan Active="false" Departure="YMAY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="220" ETD="0000" ATD="0000" RFL="18000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DUGGI1/25 DUGGI V147 TEMIS V169 ML DCT</FlightPlan>
-            <Route>SAPAN NIRIL DUGGI TEMIS BOYSE</Route>
+            <FlightPlan Active="false" Departure="YMAY" Destination="YMML" Alternative="" Rules="I" CruiseSpeed="220" ETD="0000" ATD="0000" RFL="18000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT DUGGI V147 TEMIS V169 ML DCT</FlightPlan>
+            <Route>DUGGI TEMIS BOYSE</Route>
             <TimedMessages>
-            <TimedMessage Time="200" Message="Qlink 2039 Delta, Dash 8 Delta, IFR, Taxiing Albury for Melbourne, Runway 25" />
+            <TimedMessage Time="200" Message="QLK39D, Dash 8 Delta, IFR, Taxiing Albury for Melbourne, Runway 25" />
             <TimedMessage Time="450" Message="Select Runway 25, Climb To A085, and Takeoff" />
           </TimedMessages>
           </Aircraft>
@@ -5209,42 +5219,42 @@
             <Cleared Level="24000" />
             <Position Latitude="-37.654771" Longitude="144.835207" Speed="1" Altitude="427" />
             <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="280" ETD="0000" ATD="0000" RFL="41000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DOSEL1/16 DOSEL Y59 TESAT</FlightPlan>
-            <Route>HORSH ALBAK CHIMU SALLY DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+            <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           </Aircraft>
           <Aircraft Callsign="QFA372" Type="B738" Delay="660" StartAuto="true">
             <Squawk Code="7464" ModeC="true" />
             <Cleared Level="24000" />
             <Position Latitude="-37.654379" Longitude="144.835137" Speed="1" Altitude="427" />
             <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="280" ETD="0000" ATD="0000" RFL="39000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DOSEL1/16 DOSEL Y59 TESAT</FlightPlan>
-            <Route>HORSH ALBAK CHIMU SALLY DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+            <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           </Aircraft>
           <Aircraft Callsign="BNZ24" Type="B38M" Delay="570" StartAuto="true">
             <Squawk Code="1112" ModeC="true" />
             <Cleared Level="24000" />
             <Position Latitude="-37.653652" Longitude="144.835001" Speed="1" Altitude="427" />
             <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="280" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DOSEL1/16 DOSEL Y59 TESAT</FlightPlan>
-            <Route>HORSH ALBAK CHIMU SALLY DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+            <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           </Aircraft>
           <Aircraft Callsign="JST412" Type="A320" Delay="480" StartAuto="true">
             <Squawk Code="4564" ModeC="true" />
             <Cleared Level="24000" />
             <Position Latitude="-37.654018" Longitude="144.835058" Speed="1" Altitude="427" />
             <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="280" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DOSEL1/16 DOSEL Y59 TESAT</FlightPlan>
-            <Route>HORSH ALBAK CHIMU SALLY DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+            <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           </Aircraft>
           <Aircraft Callsign="TFR44" Type="B734" Delay="390" StartAuto="true">
             <Squawk Code="5634" ModeC="true" />
             <Cleared Level="24000" />
             <Position Latitude="-37.65528" Longitude="144.83529800000002" Speed="1" Altitude="427" />
             <FlightPlan Active="true" Departure="YMML" Destination="YSSY" Alternative="" Rules="I" CruiseSpeed="260" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DOSEL1/16 DOSEL Y59 TESAT</FlightPlan>
-            <Route>HORSH ALBAK CHIMU SALLY DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
+            <Route>DOSEL EBONY ARRAN NONUP CULIN TARAL RIVET</Route>
           </Aircraft>
           <Aircraft Callsign="TFX11" Type="B462" Delay="270" StartAuto="true">
             <Squawk Code="2342" ModeC="true" />
             <Cleared Level="23000" />
             <Position Latitude="-37.655713" Longitude="144.835419" Speed="1" Altitude="427" />
             <FlightPlan Active="true" Departure="YMML" Destination="YSBK" Alternative="" Rules="I" CruiseSpeed="220" ETD="0000" ATD="0000" RFL="23000" EETHours="01" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DOSEL1/16 DOSEL Y59 CULIN WATLE Y20 BK</FlightPlan>
-            <Route>HORSH ALBAK CHIMU SALLY DOSEL EBONY ARRAN NONUP CULIN WATLE</Route>
+            <Route>DOSEL EBONY ARRAN NONUP CULIN WATLE</Route>
           </Aircraft>
           <Aircraft Callsign="QFA64" Type="B789" Delay="0">
             <Squawk Code="7213" ModeC="true" />
@@ -5376,14 +5386,14 @@
             <Cleared Level="18000" />
             <Position Latitude="-27.357767" Longitude="153.121344" Speed="1" Altitude="15" />
             <FlightPlan Active="true" Departure="YBBN" Destination="WSSS" Alternative="WMKK" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="37000" EETHours="8" EETMins="40" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/SINGAPORE    /v/">WACKO3/19R WACKO DCT HAWKE V129 EML T13 NTN DCT</FlightPlan>
-            <Route>DAMDA TOGIN IGMAS WACKO HAWKE COOLA EML MATAR LAKOT DOLIB NTN</Route>
+            <Route>WACKO HAWKE COOLA EML MATAR LAKOT DOLIB NTN</Route>
           </Aircraft>
           <Aircraft Callsign="QFA1880" Type="E190" Delay="550" StartAuto="true">
             <Squawk Code="3005" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.357767" Longitude="153.121344" Speed="1" Altitude="15" />
             <FlightPlan Active="true" Departure="YBBN" Destination="YBCS" Alternative="YBRK" Rules="I" CruiseSpeed="402" ETD="0000" ATD="0000" RFL="36000" EETHours="1" EETMins="40" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/QANTAS    /v/">BIXAD1/19R BIXAD Q67 UPOLO</FlightPlan>
-            <Route>DAMDA TOGIN ALBUB AMBLE DEBAY BUKBU BIXAD GUDSO TERUV KELPI LAMEK</Route>
+            <Route>BIXAD GUDSO TERUV KELPI LAMEK</Route>
           </Aircraft>
           <Aircraft Callsign="FD401" Type="B350" Delay="240" StartAuto="true">
             <Squawk Code="3012" ModeC="true" />
@@ -5401,35 +5411,35 @@
             <Cleared Level="18000" />
             <Position Latitude="-27.374708" Longitude="153.134358" Speed="1" Altitude="15" />
             <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="36000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/REX   /v/">SANEG1/19R SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
-            <Route>BOSVU DADAN DENIS LILEE SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
+            <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
           </Aircraft>
           <Aircraft Callsign="VOZ958" Type="B38M" Delay="1000" StartAuto="true">
             <Squawk Code="1067" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.374708" Longitude="153.134358" Speed="1" Altitude="15" />
             <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="34000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/REX   /v/">SANEG1/19R SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
-            <Route>BOSVU DADAN DENIS LILEE SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
+            <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
           </Aircraft>
             <Aircraft Callsign="VOZ962" Type="B737" Delay="1200" StartAuto="true">
             <Squawk Code="1070" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.374708" Longitude="153.134358" Speed="1" Altitude="15" />
             <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="36000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/REX   /v/">SANEG1/19R SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
-            <Route>BOSVU DADAN DENIS LILEE SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
+            <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
           </Aircraft>
           <Aircraft Callsign="JST930" Type="A320" Delay="1400" StartAuto="true">
             <Squawk Code="3643" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.357767" Longitude="153.121344" Speed="1" Altitude="15" />
             <FlightPlan Active="true" Departure="YBBN" Destination="YBCS" Alternative="YBRK" Rules="I" CruiseSpeed="402" ETD="0000" ATD="0000" RFL="36000" EETHours="1" EETMins="40" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/QANTAS    /v/">BIXAD1/19R BIXAD Q67 UPOLO</FlightPlan>
-            <Route>DAMDA TOGIN ALBUB AMBLE DEBAY BUKBU BIXAD GUDSO TERUV KELPI LAMEK</Route>
+            <Route>BIXAD GUDSO TERUV KELPI LAMEK</Route>
           </Aircraft>
           <Aircraft Callsign="QFA533" Type="B738" Delay="1600" StartAuto="true">
             <Squawk Code="1071" ModeC="true" />
             <Cleared Level="18000" />
             <Position Latitude="-27.374708" Longitude="153.134358" Speed="1" Altitude="15" />
             <FlightPlan Active="true" Departure="YBBN" Destination="YSSY" Alternative="YWLM" Rules="I" CruiseSpeed="440" ETD="0000" ATD="0000" RFL="34000" EETHours="0" EETMins="55" FuelHours="0" FuelMins="0" Remarks="CALLSIGN/REX   /v/">SANEG1/19R SANEG H91 IGDAM H12 BOREE DCT</FlightPlan>
-            <Route>BOSVU DADAN DENIS LILEE SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
+            <Route>SANEG HUUGO APAGI TESSI ADMAR SANAD MESIM IGDAM BOREE TESAT</Route>
           </Aircraft>
         </Targets>
       </ScenarioFile>
@@ -5492,9 +5502,6 @@
                   <Position Latitude="-34.836111" Longitude="152.518333" Speed="447" Altitude="37000" />
                   <FlightPlan Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Departure="YSSY" Destination="NZQN" Alternative="NZCH" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="37000" EETHours="02" EETMins="30" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1L1O1S2T1 NAV/RNP2 /v/">DCT OPTIC Y84 TONIM P766 ADKOS DCT</FlightPlan>
                   <Route>TONIM MIKEG TUVBI OMKIN DADLU ADKOS NZQN</Route>
-            <TimedMessages>
-              <TimedMessage Time="30" Message="Set Speed to Mach 0.78" />
-            </TimedMessages>
                 </Aircraft> 
                 <Aircraft Callsign="VOZ161" Type="B738" Delay="0">
                   <Squawk Code="3615" ModeC="true" />
@@ -5502,9 +5509,6 @@
                   <Position Latitude="-34.51611111" Longitude="152.05000000" Speed="447" Altitude="37000" />
                   <FlightPlan Active="true" Equipment="SDE2E3FGHIRWXYZ/LB1" Departure="YSSY" Destination="NZQN" Alternative="NZCH" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="37000" EETHours="02" EETMins="30" FuelHours="0" FuelMins="0" Remarks="PBN/A1B1C1D1L1O1S2T1 NAV/RNP2 /v/">DCT OPTIC Y84 TONIM P766 ADKOS DCT</FlightPlan>
                   <Route>TONIM MIKEG TUVBI OMKIN DADLU ADKOS NZQN</Route>
-            <TimedMessages>
-              <TimedMessage Time="30" Message="Set Speed to Mach 0.78" />
-            </TimedMessages>
                 </Aircraft>
                 <Aircraft Callsign="ANZ123" Type="B77W" Delay="0">
                   <Squawk Code="1351" ModeC="true" />

--- a/ScenarioFiles.xml
+++ b/ScenarioFiles.xml
@@ -562,7 +562,7 @@
       </InstructorNotes>
       <Targets>
           <Aircraft Callsign="JST430" Type="A320" Delay="0" StartAuto="false">
-              <Squawk Code="0" ModeC="false" />
+              <Squawk Code="2000" ModeC="false" />
               <Position Latitude="-33.935203" Longitude="151.177031" Speed="0" Altitude="3" />
               <FlightPlan Departure="YSSY" Destination="YBBN" Alternative="" Active="false" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT OLSEM Y193 BANDA H185 BN DCT</FlightPlan>
               <Route>OLSEM</Route>
@@ -583,7 +583,7 @@
               </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="VOZ821" Type="B738" Delay="0" StartAuto="false">
-              <Squawk Code="0" ModeC="false" />
+              <Squawk Code="2000" ModeC="false" />
               <Position Latitude="-33.935548" Longitude="151.17986300000004" Speed="0" Altitude="3" />
               <FlightPlan Departure="YSSY" Destination="YBBN" Alternative="" Active="false" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="39000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/   /v/">DCT OLSEM Y193 BANDA H185 BN DCT</FlightPlan>
               <Route>OLSEM</Route>
@@ -594,7 +594,7 @@
               </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="QFA820" Type="B738" Delay="1320" StartAuto="true">
-              <Squawk Code="0" ModeC="false" />
+              <Squawk Code="2000" ModeC="false" />
               <Position Latitude="-33.931913" Longitude="151.18020300000003" Speed="0" Altitude="13" />
               <FlightPlan Departure="YSSY" Destination="YBCG" Alternative="" Active="false" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="35000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT OLSEM Y193 BANDA Y43 GREAV CG DCT</FlightPlan>
               <Route>OLSEM</Route>
@@ -605,7 +605,7 @@
               </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="QFA127" Type="B744" Delay="540" StartAuto="true">
-              <Squawk Code="0" ModeC="false" />
+              <Squawk Code="2000" ModeC="false" />
               <Position Latitude="-33.938971" Longitude="151.168822" Speed="0" Altitude="13" />
               <FlightPlan Departure="YSSY" Destination="VHHH" Alternative="" Active="false" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="34000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT RIC H530 SURVO R340 DUMAV/N0468F400 R340 AMN A461 BONDA/N0471F380 A461 ZAM A583 SABNO V541</FlightPlan>
               <Route>RIC</Route>
@@ -616,7 +616,7 @@
               </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="UAE476" Type="B772" Delay="0" StartAuto="false">
-              <Squawk Code="0" ModeC="false" />
+              <Squawk Code="2000" ModeC="false" />
               <Position Latitude="-33.939237" Longitude="151.16663600000004" Speed="0" Altitude="13" />
               <FlightPlan Departure="YSSY" Destination="OMDB" Alternative="" Active="false" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="34000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT RIC UH226 ENPAG T74 KARAG/N0500F340 T74 VINAX/N0500F360 T74 TN J251 DN M768 PORAK/N0490F380 M768 TSN R468 PNH A340 RYN DCT</FlightPlan>
               <Route>RIC</Route>
@@ -627,7 +627,7 @@
               </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="QLK227D" Type="DH8D" Delay="750" StartAuto="true">
-              <Squawk Code="0" ModeC="false" />
+              <Squawk Code="2000" ModeC="false" />
               <Position Latitude="-33.931105" Longitude="151.182211" Speed="0" Altitude="13" />
               <FlightPlan Departure="YSSY" Destination="YSCB" Alternative="" Active="false" Rules="I" CruiseSpeed="350" ETD="0000" ATD="0000" RFL="22000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT PEGSU V169 CB DCT</FlightPlan>
               <Route>BUNGO</Route>
@@ -637,7 +637,7 @@
               </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="JST527" Type="A320" Delay="990" StartAuto="true">
-              <Squawk Code="0" ModeC="false" />
+              <Squawk Code="2000" ModeC="false" />
               <Position Latitude="-33.93472200000001" Longitude="151.177124" Speed="0" Altitude="3" />
               <FlightPlan Departure="YSSY" Destination="YMML" Alternative="" Active="false" Rules="I" CruiseSpeed="500" ETD="0000" ATD="0000" RFL="40000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT WOL H65 LEECE Q29 ML DCT</FlightPlan>
               <Route>WOL</Route>
@@ -648,7 +648,7 @@
               </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="VOZ429" Type="B738" Delay="0" StartAuto="false">
-              <Squawk Code="0" ModeC="false" />
+              <Squawk Code="2000" ModeC="false" />
               <Position Latitude="-33.93509300000001" Longitude="151.179945" Speed="0" Altitude="3" />
               <FlightPlan Departure="YSSY" Destination="YPAD" Alternative="" Active="false" Rules="I" CruiseSpeed="450" ETD="0000" ATD="0000" RFL="38000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT KADOM H44 BORLI W451 MIA H309 AD DCT</FlightPlan>
               <Route>KADOM</Route>
@@ -659,7 +659,7 @@
               </TimedMessages>
           </Aircraft>
           <Aircraft Callsign="CXF" Type="B350" Delay="180" StartAuto="true">
-              <Squawk Code="0" ModeC="false" />
+              <Squawk Code="2000" ModeC="false" />
               <Position Latitude="-33.934085" Longitude="151.188217" Speed="0" Altitude="20" />
               <FlightPlan Departure="YSSY" Destination="YWLM" Alternative="" Active="false" Rules="I" CruiseSpeed="250" ETD="0000" ATD="0000" RFL="9000" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">DCT WLM DCT</FlightPlan>
               <Route>WLM</Route>
@@ -1170,7 +1170,7 @@
     </InstructorNotes>
     <Targets>
       <Aircraft Callsign="QFA889" Type="B738" Delay="0" StartAuto="false">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.939807" Longitude="138.537748" Speed="0" Altitude="33" />
         <FlightPlan Departure="YPAD" Destination="YPPH" Alternative="" Active="false" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="36000" EETHours="3" EETMins="15" FuelHours="4" FuelMins="50" Remarks="NAV/RNP2 RTF/QANTAS /v/">DCT GILES Q33 ESP Q158 KABLI DCT</FlightPlan>
         <Route>COLPY</Route>
@@ -1181,7 +1181,7 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="VOZ441" Type="B738" Delay="0" StartAuto="false">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.93780799999999" Longitude="138.54068300000003" Speed="0" Altitude="33" />
         <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="false" Rules="I" CruiseSpeed="452" ETD="0000" ATD="0000" RFL="39000" EETHours="1" EETMins="57" FuelHours="3" FuelMins="07" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT AVDEN H247 CULIN Y59 RIVET DCT</FlightPlan>
         <Route>COLPY</Route>
@@ -1192,7 +1192,7 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="JST779" Type="A320" Delay="0" StartAuto="false">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.940805" Longitude="138.536216" Speed="0" Altitude="33" />
         <FlightPlan Departure="YPAD" Destination="YMML" Alternative="" Active="false" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="37000" EETHours="0" EETMins="59" FuelHours="1" FuelMins="59" Remarks="NAV/RNP2 RTF/JETSTAR /v/">DCT BENDO Y12 ARBEY DCT</FlightPlan>
         <Route>COLPY</Route>
@@ -1203,7 +1203,7 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="FJS" Type="C182" Delay="0" StartAuto="false">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="1200" ModeC="false" />
         <Position Latitude="-34.938908" Longitude="138.53142499999998" Speed="0" Altitude="23" />
         <FlightPlan Departure="YPAD" Destination="YADG" Alternative="" Active="false" Rules="V" CruiseSpeed="110" ETD="0000" ATD="0000" RFL="2500" EETHours="00" EETMins="00" FuelHours="0" FuelMins="0" Remarks="/v/">BTJ PNL</FlightPlan>
         <Route>BTJ PNL</Route>
@@ -1213,7 +1213,7 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="FD580" Type="PC12" Delay="120" StartAuto="true">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.950071" Longitude="138.522121" Speed="0" Altitude="23" />
         <FlightPlan Departure="YPAD" Destination="YWHA" Alternative="" Active="false" Rules="I" CruiseSpeed="284" ETD="0000" ATD="0000" RFL="16000" EETHours="00" EETMins="34" FuelHours="3" FuelMins="00" Remarks="NAV/RNP2 RTF/FLYDOC /v/">DCT AD W238 RUKNA W142 COMAC DCT </FlightPlan>
         <Route>COLPY</Route>
@@ -1223,7 +1223,7 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="QFA1950" Type="E190" Delay="240" StartAuto="true">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.941057" Longitude="138.535877" Speed="0" Altitude="33" />
         <FlightPlan Departure="YPAD" Destination="YPDN" Alternative="" Active="false" Rules="I" CruiseSpeed="447" ETD="0000" ATD="0000" RFL="34000" EETHours="4" EETMins="02" FuelHours="6" FuelMins="02" Remarks="NAV/RNP2 RTF/QANTAS /v/">DCT AREPA J58 WHA J251 GREGA/M078F360 J251 TN Q23 VEGPU DCT </FlightPlan>
         <Route>COLPY</Route>
@@ -1234,7 +1234,7 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="FD578" Type="PC12" Delay="660" StartAuto="true">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.95057" Longitude="138.52138700000003" Speed="0" Altitude="23" />
         <FlightPlan Departure="YPAD" Destination="YLOX" Alternative="" Active="false" Rules="I" CruiseSpeed="268" ETD="0000" ATD="0000" RFL="15000" EETHours="00" EETMins="34" FuelHours="3" FuelMins="00" Remarks="NAV/RNP2 RTF/FLYDOC /v/">DCT AD V361 UPROT DCT </FlightPlan>
         <Route>COLPY</Route>
@@ -1244,7 +1244,7 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="QFA734" Type="B738" Delay="840" StartAuto="true">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.940313" Longitude="138.536973" Speed="0" Altitude="33" />
         <FlightPlan Departure="YPAD" Destination="YSSY" Alternative="" Active="false" Rules="I" CruiseSpeed="452" ETD="0000" ATD="0000" RFL="37000" EETHours="1" EETMins="48" FuelHours="2" FuelMins="59" Remarks="NAV/RNP2 RTF/QANTAS /v/">DCT AVDEN H247 CULIN Y59 RIVET DCT</FlightPlan>
         <Route>COLPY</Route>
@@ -1255,7 +1255,7 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="QLK275" Type="DH8C" Delay="1080" StartAuto="true">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.940631" Longitude="138.534835" Speed="0" Altitude="33" />
         <FlightPlan Departure="YPAD" Destination="YPLC" Alternative="" Active="false" Rules="I" CruiseSpeed="284" ETD="0000" ATD="0000" RFL="16000" EETHours="00" EETMins="36" FuelHours="3" FuelMins="02" Remarks="NAV/RNP2 RTF/QLINK /v/">DCT AD J15 TEDUS V538 PLC DCT</FlightPlan>
         <Route>COLPY</Route>
@@ -1266,7 +1266,7 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="QTR914" Type="B77W" Delay="1380" StartAuto="true">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.939256" Longitude="138.538447" Speed="0" Altitude="33" />
         <FlightPlan Departure="YPAD" Destination="NZAA" Alternative="" Active="false" Rules="I" CruiseSpeed="485" ETD="0000" ATD="0000" RFL="35000" EETHours="3" EETMins="59" FuelHours="5" FuelMins="16" Remarks="NAV/RNP2 RTF/QATARI /v/">DCT BENDO Y12 APPLE Y108 GEMAC N759 SASRO/M083F370 N759 PEBLU DCT</FlightPlan>
         <Route>COLPY</Route>
@@ -1277,13 +1277,13 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="RXA4136" Type="SF34" Delay="1500" StartAuto="true">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.937141" Longitude="138.541821" Speed="0" Altitude="36" />
         <FlightPlan Departure="YPAD" Destination="YCDU" Alternative="" Active="false" Rules="I" CruiseSpeed="284" ETD="0000" ATD="0000" RFL="18000" EETHours="1" EETMins="30" FuelHours="4" FuelMins="10" Remarks="NAV/RNP2 RTF/REX /v/">DCT AD A585 CDU DCT</FlightPlan>
         <Route>COLPY</Route>
       </Aircraft>
       <Aircraft Callsign="VOZ1407" Type="B738" Delay="1980" StartAuto="true">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.938591" Longitude="138.5396" Speed="0" Altitude="33" />
         <FlightPlan Departure="YPAD" Destination="YBBN" Alternative="" Active="false" Rules="I" CruiseSpeed="432" ETD="0000" ATD="0000" RFL="39000" EETHours="2" EETMins="10" FuelHours="3" FuelMins="37" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT UPROT Y465 ENLIP DCT </FlightPlan>
         <Route>COLPY</Route>
@@ -1294,7 +1294,7 @@
         </TimedMessages>
       </Aircraft>
       <Aircraft Callsign="VOZ238" Type="B738" Delay="2340" StartAuto="true">
-        <Squawk Code="0" ModeC="false" />
+        <Squawk Code="2000" ModeC="false" />
         <Position Latitude="-34.938321" Longitude="138.539942" Speed="0" Altitude="33" />
         <FlightPlan Departure="YPAD" Destination="YMML" Alternative="" Active="false" Rules="I" CruiseSpeed="455" ETD="0000" ATD="0000" RFL="37000" EETHours="01" EETMins="02" FuelHours="2" FuelMins="43" Remarks="NAV/RNP2 RTF/VELOCITY /v/">DCT BENDO Y12 ARBEY DCT</FlightPlan>
         <Route>COLPY</Route>


### PR DESCRIPTION
- Changes for **AIRAC 2406**, including:
    - Airway naming updates (UQ, UH airways > Q, H, etc)
    - BEVLY > KABLI
    - HAMTN > MALUP
    - PANKI > AVDEN
    - SEDAN > UPROT
    - HAWKY > AREPA
    - ROGAS > DADRU
    - RAZZI > LEECE
    - ROWLO > IDLEG
    - QDI > NIXUG
    - SCO > LALIB
    - GRENE > LAVEX
    - YHOT > OMBIS
    - YOLD > GOKIB
    - GDH > OLRON
    - NIROK > BESBO (Old change)
    - HAWKE > IGUPI (Old change)
    - WAKEN > RUKNA (Old change)
    - LLOYD > IGNES (Old change)
    - BENDO2 > BENDO3

- Changes to **TBD** scenario
    - Removed some aircraft to make it more manageable
    - Moved position of VOZ223 slightly to make it more easy to select
    - Fixed incorrect callsigns and runways in some timed messages

- Changes to **PIY** scenario
    - Fixed aircraft with no destination
    - Fixed aircraft with incorrect planned routes
    - Fixed out-of-date waypoints

- Changes to **INL** scenario
    - Fixed aircraft with incorrect routing to YBCS
    - Fixed aircraft with incorrect Runway set for departure via SANEG

- Removed unnecessary waypoints in target's routes that are automatically added by the simulator (ie SIDs and STARs)
- Added Timed Messages for broken routes requiring waypoints to be added
- General Timed Message Phraseology adjustments, including
    - Selecting Runway prior to takeoff from OCTA aerodrome
    - Setting Cleared level to CTA LL prior to takeoff from OCTA aerodrome
    - Added detail to 'Next' Calls where required
    - Coordination format standardisation